### PR TITLE
Notify errors

### DIFF
--- a/.github/workflows/update-ncov-case-counts.yaml
+++ b/.github/workflows/update-ncov-case-counts.yaml
@@ -70,3 +70,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         TRIAL_NAME: ${{ github.event.inputs.trial_name }}
+
+    - name: notify_pipeline_failed
+      if: ${{ failure() }}
+      run: ./ingest/bin/notify-on-job-fail

--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -17,6 +17,9 @@ on:
 jobs:
   gisaid_clade_counts:
     runs-on: ubuntu-latest
+    env:
+      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+      SLACK_CHANNELS: ${{ github.event.inputs.slack_channel || 'nextstrain-counts-updates' }}
     defaults:
       run:
         # Login shell is required to include changes by conda init bash.
@@ -82,6 +85,8 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        SLACK_CHANNELS: ${{ github.event.inputs.slack_channel || 'nextstrain-counts-updates' }}
         TRIAL_NAME: ${{ github.event.inputs.trial_name }}
+
+    - name: notify_pipeline_failed
+      if: ${{ failure() }}
+      run: ./ingest/bin/notify-on-job-fail

--- a/.github/workflows/update-ncov-open-clade-counts.yaml
+++ b/.github/workflows/update-ncov-open-clade-counts.yaml
@@ -18,6 +18,9 @@ on:
 jobs:
   open_clade_counts:
     runs-on: ubuntu-latest
+    env:
+      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+      SLACK_CHANNELS: ${{ github.event.inputs.slack_channel || 'nextstrain-counts-updates' }}
     defaults:
       run:
         # Login shell is required to include changes by conda init bash.
@@ -84,6 +87,8 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        SLACK_CHANNELS: ${{ github.event.inputs.slack_channel || 'nextstrain-counts-updates' }}
         TRIAL_NAME: ${{ github.event.inputs.trial_name }}
+
+    - name: notify_pipeline_failed
+      if: ${{ failure() }}
+      run: ./ingest/bin/notify-on-job-fail

--- a/ingest/bin/notify-on-job-fail
+++ b/ingest/bin/notify-on-job-fail
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
+: "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
+
+: "${AWS_BATCH_JOB_ID:=}"
+: "${GITHUB_RUN_ID:=}"
+
+bin="$(dirname "$0")"
+
+echo "Notifying Slack about failed ingest job."
+message="❌ Ingest job has FAILED 😞 "
+
+if [ -n "${AWS_BATCH_JOB_ID}" ]; then
+    message+="See AWS Batch job \`${AWS_BATCH_JOB_ID}\` (<https://console.aws.amazon.com/batch/v2/home?region=us-east-1#jobs/detail/${AWS_BATCH_JOB_ID}|link>) for error details. "
+elif [ -n "${GITHUB_RUN_ID}" ]; then
+    message+="See GitHub Action <https://github.com/nextstrain/monkeypox/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true|${GITHUB_RUN_ID}> for error details. "
+fi
+
+"$bin"/notify-slack "$message"


### PR DESCRIPTION
### Description of proposed changes
Notify Slack of errors when the automated ingest GH workflows fail. 
Prevents errors from happening silently because jobs are triggered by the nextstrain-bot (Example: [failures](https://github.com/nextstrain/forecasts-ncov/actions/workflows/update-ncov-open-clade-counts.yaml?query=is%3Afailure) of recent GenBank clade counts). 
