### PR TITLE
Move all outputs to public S3 bucket

### DIFF
--- a/.github/workflows/run-models.yaml
+++ b/.github/workflows/run-models.yaml
@@ -10,7 +10,7 @@ on:
         description: 'Slack channel to push update alerts. Default channel is nextstrain-counts-updates.'
         required: false
       trial_name:
-        description: 'Short name for a trial run that does not send Slack notifications. WARNING: without this we will overwrite files in s3://nextstrain-data/files/workflows/forecasts-ncov and s3://nextstrain-data-private/files/workflows/forecasts-ncov'
+        description: 'Short name for a trial run that does not send Slack notifications. WARNING: without this we will overwrite files in s3://nextstrain-data/files/workflows/forecasts-ncov'
         required: false
       data_provenance:
         description: 'Data provenance of data inputs for model: gisaid or open. Will run both if left empty.'

--- a/.github/workflows/update-ncov-case-counts.yaml
+++ b/.github/workflows/update-ncov-case-counts.yaml
@@ -9,7 +9,7 @@ on:
         description: 'Slack channel to push update alerts. Default channel is nextstrain-counts-updates.'
         required: false
       trial_name:
-        description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data/files/workflows/forecasts-ncov and s3://nextstrain-data-private/files/workflows/forecasts-ncov'
+        description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data/files/workflows/forecasts-ncov/cases.'
         required: false
 
 jobs:
@@ -46,25 +46,15 @@ jobs:
 
     - name: upload to S3
       run: |
-        S3_DSTS=(
-          s3://nextstrain-data/files/workflows/forecasts-ncov
-          s3://nextstrain-data-private/files/workflows/forecasts-ncov
-        )
-        CLOUDFRONT_DOMAIN=""
+        S3_DST=s3://nextstrain-data/files/workflows/forecasts-ncov/cases
+        CLOUDFRONT_DOMAIN="data.nextstrain.org"
 
-        for S3_DST in ${S3_DSTS[@]}; do
+        if [[ "$TRIAL_NAME" ]]; then
+          S3_DST+=/trial/"$TRIAL_NAME"
+        fi
 
-          if [[ "$TRIAL_NAME" ]]; then
-            S3_DST+=/trial/"$TRIAL_NAME"
-          fi
-
-          if [[ $S3_DST == s3://nextstrain-data/* ]]; then
-            CLOUDFRONT_DOMAIN="data.nextstrain.org"
-          fi
-
-          ./ingest/bin/upload-to-s3 global_case_counts.tsv "$S3_DST"/global/cases.tsv.gz $CLOUDFRONT_DOMAIN
-          ./ingest/bin/upload-to-s3 us_case_counts.tsv "$S3_DST"/usa/cases.tsv.gz $CLOUDFRONT_DOMAIN
-        done
+        ./ingest/bin/upload-to-s3 global_case_counts.tsv "$S3_DST"/global.tsv.gz $CLOUDFRONT_DOMAIN
+        ./ingest/bin/upload-to-s3 us_case_counts.tsv "$S3_DST"/usa.tsv.gz $CLOUDFRONT_DOMAIN
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -79,8 +79,8 @@ jobs:
           S3_DST+=/trial/"$TRIAL_NAME"
         fi
 
-        ./ingest/bin/upload-to-s3 global_clade_counts.tsv "$S3_DST"/global/nextstrain_clades.tsv.gz
-        ./ingest/bin/upload-to-s3 us_clade_counts.tsv "$S3_DST"/usa/nextstrain_clades.tsv.gz
+        ./ingest/bin/upload-to-s3 global_clade_counts.tsv "$S3_DST"/nextstrain_clades/global.tsv.gz
+        ./ingest/bin/upload-to-s3 us_clade_counts.tsv "$S3_DST"/nextstrain_clades/usa.tsv.gz
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -11,7 +11,7 @@ on:
         description: 'Slack channel to push update alerts. Default channel is nextstrain-counts-updates.'
         required: false
       trial_name:
-        description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data-private/files/workflows/forecasts-ncov'
+        description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data/files/workflows/forecasts-ncov/gisaid'
         required: false
 
 jobs:
@@ -73,7 +73,7 @@ jobs:
 
     - name: upload clade counts
       run: |
-        S3_DST=s3://nextstrain-data-private/files/workflows/forecasts-ncov
+        S3_DST=s3://nextstrain-data/files/workflows/forecasts-ncov/gisaid
 
         if [[ "$TRIAL_NAME" ]]; then
           S3_DST+=/trial/"$TRIAL_NAME"

--- a/.github/workflows/update-ncov-open-clade-counts.yaml
+++ b/.github/workflows/update-ncov-open-clade-counts.yaml
@@ -81,8 +81,8 @@ jobs:
           S3_DST+=/trial/"$TRIAL_NAME"
         fi
 
-        ./ingest/bin/upload-to-s3 global_clade_counts.tsv "$S3_DST"/global/nextstrain_clades.tsv.gz $CLOUDFRONT_DOMAIN
-        ./ingest/bin/upload-to-s3 us_clade_counts.tsv "$S3_DST"/usa/nextstrain_clades.tsv.gz $CLOUDFRONT_DOMAIN
+        ./ingest/bin/upload-to-s3 global_clade_counts.tsv "$S3_DST"/nextstrain_clades/global.tsv.gz $CLOUDFRONT_DOMAIN
+        ./ingest/bin/upload-to-s3 us_clade_counts.tsv "$S3_DST"/nextstrain_clades/usa.tsv.gz $CLOUDFRONT_DOMAIN
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/update-ncov-open-clade-counts.yaml
+++ b/.github/workflows/update-ncov-open-clade-counts.yaml
@@ -12,7 +12,7 @@ on:
         description: 'Slack channel to push update alerts. Default channel is nextstrain-counts-updates.'
         required: false
       trial_name:
-        description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data/files/workflows/forecasts-ncov'
+        description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data/files/workflows/forecasts-ncov/open'
         required: false
 
 jobs:
@@ -74,7 +74,7 @@ jobs:
 
     - name: upload clade counts
       run: |
-        S3_DST=s3://nextstrain-data/files/workflows/forecasts-ncov
+        S3_DST=s3://nextstrain-data/files/workflows/forecasts-ncov/open
         CLOUDFRONT_DOMAIN=data.nextstrain.org
 
         if [[ "$TRIAL_NAME" ]]; then

--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ See [available counts files](./ingest/README.md#outputs) for the input case coun
 The model results for GISAID data are stored at `s3://nextstrain-data/files/workflows/forecasts-ncov/gisaid`.
 The model results for open (GenBank) data are stored at `s3://nextstrain-data/files/workflows/forecasts-ncov/open`.
 
-The latest results are stored as `latest_results.json.gz` and previously uploaded results can be found as `<YYYY-MM-DD>_results.json.gz`.
+The latest results are stored as `latest_results.json` and previously uploaded results can be found as `<YYYY-MM-DD>_results.json`.
 
 #### Summary of Available files:
 
 | Data Provenance | Clade Type        | Geographic Resolution | Model   | Address |
 | --------------- | ----------------- | --------------------- | ------- | ------- |
-| GISAID          | Nextstrain clades | Global                | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/global/mlr/latest_results.json.gz`    |
-|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/global/renewal/latest_results.json.gz`|
-|                 |                   | USA                   | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/usa/mlr/latest_results.json.gz`       |
-|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/usa/renewal/latest_results.json.gz`   |
-| open (GenBank)  | Nextstrain clades | Global                | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/global/mlr/latest_results.json.gz`      |
-|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/global/renewal/latest_results.json.gz`  |
-|                 |                   | USA                   | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/usa/mlr/latest_results.json.gz`         |
-|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/usa/renewal/latest_results.json.gz`     |
+| GISAID          | Nextstrain clades | Global                | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/global/mlr/latest_results.json`    |
+|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/global/renewal/latest_results.json`|
+|                 |                   | USA                   | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/usa/mlr/latest_results.json`       |
+|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/usa/renewal/latest_results.json`   |
+| open (GenBank)  | Nextstrain clades | Global                | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/global/mlr/latest_results.json`      |
+|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/global/renewal/latest_results.json`  |
+|                 |                   | USA                   | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/usa/mlr/latest_results.json`         |
+|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/usa/renewal/latest_results.json`     |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,23 @@ The automated pipeline runs daily based on a scheduled jobs and triggers from up
 See [available counts files](./ingest/README.md#outputs) for the input case counts and clade counts files.
 
 ### Outputs
-The model results for GISAID data are stored at `s3://nextstrain-data-private/files/workflows/forecasts-ncov/` and are not publicly available.
+The model results for GISAID data are stored at `s3://nextstrain-data/files/workflows/forecasts-ncov/gisaid`.
+The model results for open (GenBank) data are stored at `s3://nextstrain-data/files/workflows/forecasts-ncov/open`.
 
-The model results for open (GenBank) data are stored at `s3://nextstrain-data/files/workflows/forecasts-ncov` and are publicly available:
+The latest results are stored as `latest_results.json.gz` and previously uploaded results can be found as `<YYYY-MM-DD>_results.json.gz`.
 
-| Geographic Resolution | Model | Address |
-| --- | --- | --- |
-| Global | MLR | `https://data.nextstrain.org/files/workflows/forecasts-ncov/global/mlr/<YYYY-MM-DD>_results.json.zst` |
-|        | Renewal |  `https://data.nextstrain.org/files/workflows/forecasts-ncov/global/renewal/<YYYY-MM-DD>_results.json.zst` |
-| USA | MLR |  `https://data.nextstrain.org/files/workflows/forecasts-ncov/usa/mlr/<YYYY-MM-DD>_results.json.zst` |
-|     | Renewal |  `https://data.nextstrain.org/files/workflows/forecasts-ncov/usa/renewal/<YYYY-MM-DD>_results.json.zst` |
+#### Summary of Available files:
+
+| Data Provenance | Clade Type        | Geographic Resolution | Model   | Address |
+| --------------- | ----------------- | --------------------- | ------- | ------- |
+| GISAID          | Nextstrain clades | Global                | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/global/mlr/latest_results.json.gz`    |
+|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/global/renewal/latest_results.json.gz`|
+|                 |                   | USA                   | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/usa/mlr/latest_results.json.gz`       |
+|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/usa/renewal/latest_results.json.gz`   |
+| open (GenBank)  | Nextstrain clades | Global                | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/global/mlr/latest_results.json.gz`      |
+|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/global/renewal/latest_results.json.gz`  |
+|                 |                   | USA                   | MLR     | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/usa/mlr/latest_results.json.gz`         |
+|                 |                   |                       | Renewal | `https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/usa/renewal/latest_results.json.gz`     |
 
 ## Installation
 

--- a/Snakefile
+++ b/Snakefile
@@ -70,7 +70,10 @@ def _get_all_input(w):
         ))
         if config.get("upload"):
             all_input.extend(expand(
-                "results/{data_provenance}/{geo_resolution}/{model}/{date}_results_s3_upload.done",
+                [
+                    "results/{data_provenance}/{geo_resolution}/{model}/{date}_results_s3_upload.done",
+                    "results/{data_provenance}/{geo_resolution}/{model}/{date}_latest_results_s3_upload.done"
+                ],
                 data_provenance=data_provenances,
                 geo_resolution=geo_resolutions,
                 model=models_to_run,

--- a/bin/nextstrain-remote-upload-with-slack-notification
+++ b/bin/nextstrain-remote-upload-with-slack-notification
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+base="$(realpath "$(dirname "$0")/..")"
+ingest_bin="$base/ingest/bin"
+
+main() {
+    local quiet=0
+
+    for arg; do
+        case "$arg" in
+            --quiet)
+                quiet=1
+                shift;;
+            *)
+                break;;
+        esac
+    done
+
+    local remote_url="${1:?A remote destination S3 URL is required as the first argument.}"
+    local file_to_upload="${2:?A local file to upload is required as the second argument.}"
+
+    nextstrain remote upload "$remote_url" "$file_to_upload"
+
+    if [[ $quiet == 1 ]]; then
+        echo "Quiet mode. No Slack notification sent."
+        exit 0
+    fi
+
+    # Based on the nextstrain remote upload behavior for an S3 remote URL,
+    # the basename of the local file is used in combination with the remote URL in the final remote destination URL.
+    local dst="$remote_url$(basename "$file_to_upload")"
+
+    if ! "$ingest_bin"/notify-slack "Updated $dst available."; then
+        echo "Notifying Slack failed, but exiting with success anyway."
+    fi
+
+}
+
+main "$@"

--- a/config/optional.yaml
+++ b/config/optional.yaml
@@ -4,11 +4,9 @@ upload:
   gisaid:
     # AWS S3 Bucket with prefix
     s3_dst: "s3://nextstrain-data/files/workflows/forecasts-ncov/gisaid"
-    cloudfront_domain: "data.nextstrain.org"
   open:
     # AWS S3 Bucket with prefix
     s3_dst: "s3://nextstrain-data/files/workflows/forecasts-ncov/open"
-    cloudfront_domain: "data.nextstrain.org"
 
 # Send Slack notifications
 send_slack_notifications: True

--- a/config/optional.yaml
+++ b/config/optional.yaml
@@ -3,10 +3,11 @@
 upload:
   gisaid:
     # AWS S3 Bucket with prefix
-    s3_dst: "s3://nextstrain-data-private/files/workflows/forecasts-ncov"
+    s3_dst: "s3://nextstrain-data/files/workflows/forecasts-ncov/gisaid"
+    cloudfront_domain: "data.nextstrain.org"
   open:
     # AWS S3 Bucket with prefix
-    s3_dst: "s3://nextstrain-data/files/workflows/forecasts-ncov"
+    s3_dst: "s3://nextstrain-data/files/workflows/forecasts-ncov/open"
     cloudfront_domain: "data.nextstrain.org"
 
 # Send Slack notifications

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -12,23 +12,31 @@ Internal tooling for the Nextstrain team to curate and standardize various count
 
 > :warning: **WARNING: This is an alpha release.** Output file format and address may change at any time
 
-This repository produces multiple TSVs that are routinely uploaded to AWS S3 buckets.
+This repository produces multiple TSVs that are routinely uploaded to a public AWS S3 bucket: `s3://nextstrain-data/files/workflows/forecasts-ncov`.
 
-The GISAID data is stored at `s3://nextstrain-data-private/files/workflows/forecasts-ncov/` and is not publicly available.
-The open (GenBank) data is stored at `s3://nextstrain-data/files/workflows/forecasts-ncov` and is publicly available.
+The case counts are stored at `s3://nextstrain-data/files/workflows/forecasts-ncov/cases/`.
+The GISAID outputs are stored at `s3://nextstrain-data/files/workflows/forecasts-ncov/gisaid/`.
+The open (GenBank) outputs are stored at `s3://nextstrain-data/files/workflows/forecasts-ncov/open/`.
 
-Within `forecasts-ncov/`, files are organized by geographic resolution and count type.
+Within each data provenance, the files are split by clade type and geographic resolution.
 Within TSVs at the global resolution, the `location` column contains countries.
 Within TSVs at the country resolution, the `location` column contains divisions (e.g. states for US).
 
-### Summary of Available open (GenBank) files
+### Summary of Available files
 
-| Geographic Resolution  | Type | Address |
-| --- | --- | --- |
-| Global | Cases | https://data.nextstrain.org/files/workflows/forecasts-ncov/global/cases.tsv.gz |
-|        | Nextstrain clades | https://data.nextstrain.org/files/workflows/forecasts-ncov/global/nextstrain_clades.tsv.gz |
-| USA    | Cases | https://data.nextstrain.org/files/workflows/forecasts-ncov/usa/cases.tsv.gz |
-|        | Nextstrain clades | https://data.nextstrain.org/files/workflows/forecasts-ncov/usa/nextstrain_clades.tsv.gz |
+#### Case Counts
+| Geographic Resolution | Address                                                                        |
+| --------------------- | ------------------------------------------------------------------------------ |
+| Global                | https://data.nextstrain.org/files/workflows/forecasts-ncov/cases/global.tsv.gz |
+| USA                   | https://data.nextstrain.org/files/workflows/forecasts-ncov/cases/usa.tsv.gz    |
+
+#### Sequence Counts
+| Data Provenance | Clade Type        | Geographic Resolution | Address                                                                                           |
+| --------------- | ----------------- | --------------------- | ------------------------------------------------------------------------------------------------- |
+| GISAID          | Nextstrain clades | Global                | https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/global.tsv.gz |
+|                 |                   | USA                   | https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/usa.tsv.gz    |
+| open (GenBank)  | Nextstrain clades | Global                | https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/global.tsv.gz   |
+|                 |                   | USA                   | https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/usa.tsv.gz      |
 
 ## Running locally
 

--- a/workflow/snakemake_rules/prepare_data.smk
+++ b/workflow/snakemake_rules/prepare_data.smk
@@ -2,36 +2,24 @@
 This part of the workflow downloads and prepares the data necessary to run models
 """
 
-rule download_open_data:
-    message: "Downloading case counts and Nextstrain clade counts from data.nextstrain.org"
-    wildcard_constraints:
-        geo_resolution = "global|usa"
+rule download_case_counts:
     output:
-        cases = "data/open/{geo_resolution}/cases.tsv.gz",
-        nextstrain_clades = "data/open/{geo_resolution}/nextstrain_clades.tsv.gz"
+        cases = "data/cases/{geo_resolution}.tsv.gz"
     params:
-        cases_url = "https://data.nextstrain.org/files/workflows/forecasts-ncov/{geo_resolution}/cases.tsv.gz",
-        nextstrain_clades_url = "https://data.nextstrain.org/files/workflows/forecasts-ncov/{geo_resolution}/nextstrain_clades.tsv.gz"
+        cases_url = "https://data.nextstrain.org/files/workflows/forecasts-ncov/cases/{geo_resolution}.tsv.gz"
     shell:
         """
         curl -fsSL --compressed {params.cases_url:q} --output {output.cases}
-        curl -fsSL --compressed {params.nextstrain_clades_url:q} --output {output.nextstrain_clades}
         """
 
-rule download_gisaid_data:
-    message: "Downloading case counts and Nextstrain clade counts from s3://nextstrain-data-private"
-    wildcard_constraints:
-        geo_resolution = "global|usa"
+rule download_clade_counts:
     output:
-        cases = "data/gisaid/{geo_resolution}/cases.tsv.gz",
-        nextstrain_clades = "data/gisaid/{geo_resolution}/nextstrain_clades.tsv.gz"
+        clades = "data/{data_provenance}/nextstrain_clades/{geo_resolution}.tsv.gz"
     params:
-        cases_url = "s3://nextstrain-data-private/files/workflows/forecasts-ncov/{geo_resolution}/cases.tsv.gz",
-        nextstrain_clades_url = "s3://nextstrain-data-private/files/workflows/forecasts-ncov/{geo_resolution}/nextstrain_clades.tsv.gz"
+        clades_url = "https://data.nextstrain.org/files/workflows/forecasts-ncov/{data_provenance}/nextstrain_clades/{geo_resolution}.tsv.gz"
     shell:
         """
-        aws s3 cp --no-progress {params.cases_url:q} {output.cases}
-        aws s3 cp --no-progress {params.nextstrain_clades_url:q} {output.nextstrain_clades}
+        curl -fsSL --compressed {params.clades_url:q} --output {output.clades}
         """
 
 def _get_prepare_data_option(wildcards, option_name):
@@ -58,8 +46,8 @@ def _get_prepare_data_option(wildcards, option_name):
 rule prepare_data:
     message: "Preparing counts data for analysis"
     input:
-        cases = "data/{data_provenance}/{geo_resolution}/cases.tsv.gz",
-        nextstrain_clades = "data/{data_provenance}/{geo_resolution}/nextstrain_clades.tsv.gz"
+        cases = "data/cases/{geo_resolution}.tsv.gz",
+        nextstrain_clades = "data/{data_provenance}/nextstrain_clades/{geo_resolution}.tsv.gz"
     output:
         clade_without_variant = "data/{data_provenance}/{geo_resolution}/clade_without_variant.txt",
         cases = "data/{data_provenance}/{geo_resolution}/prepared_cases.tsv",

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -34,3 +34,21 @@ rule upload_model_results_to_s3:
             {params.s3_dst:q}/{wildcards.geo_resolution:q}/{wildcards.model:q}/{wildcards.date}_results.json.gz \
             {params.cloudfront_domain} 2>&1 | tee {output.upload_flag}
         """
+
+rule upload_model_results_to_s3_as_latest:
+    input:
+        model_results = "results/{data_provenance}/{geo_resolution}/{model}/{date}_results.json"
+    output:
+        upload_flag = "results/{data_provenance}/{geo_resolution}/{model}/{date}_latest_results_s3_upload.done"
+    params:
+        quiet="" if send_notifications else "--quiet",
+        s3_dst=lambda wildcards: config["upload"].get(wildcards.data_provenance, {}).get("s3_dst", ""),
+        cloudfront_domain=lambda wildcards: config["upload"].get(wildcards.data_provenance, {}).get("cloudfront_domain", "")
+    shell:
+        """
+        ./ingest/bin/upload-to-s3 \
+            {params.quiet} \
+            {input.model_results:q} \
+            {params.s3_dst:q}/{wildcards.geo_resolution:q}/{wildcards.model:q}/latest_results.json.gz \
+            {params.cloudfront_domain} 2>&1 | tee {output.upload_flag}
+        """

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -31,6 +31,6 @@ rule upload_model_results_to_s3:
         ./ingest/bin/upload-to-s3 \
             {params.quiet} \
             {input.model_results:q} \
-            {params.s3_dst:q}/{wildcards.geo_resolution:q}/{wildcards.model:q}/{wildcards.date}_results.json.zst \
+            {params.s3_dst:q}/{wildcards.geo_resolution:q}/{wildcards.model:q}/{wildcards.date}_results.json.gz \
             {params.cloudfront_domain} 2>&1 | tee {output.upload_flag}
         """

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -31,7 +31,7 @@ rule upload_model_results_to_s3:
         ./ingest/bin/upload-to-s3 \
             {params.quiet} \
             {input.model_results:q} \
-            {params.s3_dst:q}/{wildcards.geo_resolution:q}/{wildcards.model:q}/{wildcards.date}_results.json.gz \
+            {params.s3_dst:q}/nextstrain_clades/{wildcards.geo_resolution:q}/{wildcards.model:q}/{wildcards.date}_results.json.gz \
             {params.cloudfront_domain} 2>&1 | tee {output.upload_flag}
         """
 
@@ -49,6 +49,6 @@ rule upload_model_results_to_s3_as_latest:
         ./ingest/bin/upload-to-s3 \
             {params.quiet} \
             {input.model_results:q} \
-            {params.s3_dst:q}/{wildcards.geo_resolution:q}/{wildcards.model:q}/latest_results.json.gz \
+            {params.s3_dst:q}/nextstrain_clades/{wildcards.geo_resolution:q}/{wildcards.model:q}/latest_results.json.gz \
             {params.cloudfront_domain} 2>&1 | tee {output.upload_flag}
         """

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -21,34 +21,40 @@ rule upload_model_results_to_s3:
     input:
         model_results = "results/{data_provenance}/{geo_resolution}/{model}/{date}_results.json"
     output:
-        upload_flag = "results/{data_provenance}/{geo_resolution}/{model}/{date}_results_s3_upload.done"
+        touch("results/{data_provenance}/{geo_resolution}/{model}/{date}_results_s3_upload.done")
     params:
         quiet="" if send_notifications else "--quiet",
         s3_dst=lambda wildcards: config["upload"].get(wildcards.data_provenance, {}).get("s3_dst", ""),
-        cloudfront_domain=lambda wildcards: config["upload"].get(wildcards.data_provenance, {}).get("cloudfront_domain", "")
     shell:
         """
-        ./ingest/bin/upload-to-s3 \
+        ./bin/nextstrain-remote-upload-with-slack-notification \
             {params.quiet} \
-            {input.model_results:q} \
-            {params.s3_dst:q}/nextstrain_clades/{wildcards.geo_resolution:q}/{wildcards.model:q}/{wildcards.date}_results.json.gz \
-            {params.cloudfront_domain} 2>&1 | tee {output.upload_flag}
+            {params.s3_dst:q}/nextstrain_clades/{wildcards.geo_resolution:q}/{wildcards.model:q}/ \
+            {input.model_results}
+        """
+
+rule copy_dated_model_results_to_latest:
+    input:
+        dated_model_results = "results/{data_provenance}/{geo_resolution}/{model}/{date}_results.json"
+    output:
+        latest_model_results = "results/{data_provenance}/{geo_resolution}/{model}/{date}/latest_results.json"
+    shell:
+        """
+        cp {input.dated_model_results} {output.latest_model_results}
         """
 
 rule upload_model_results_to_s3_as_latest:
     input:
-        model_results = "results/{data_provenance}/{geo_resolution}/{model}/{date}_results.json"
+        model_results = "results/{data_provenance}/{geo_resolution}/{model}/{date}/latest_results.json"
     output:
-        upload_flag = "results/{data_provenance}/{geo_resolution}/{model}/{date}_latest_results_s3_upload.done"
+        touch("results/{data_provenance}/{geo_resolution}/{model}/{date}_latest_results_s3_upload.done")
     params:
         quiet="" if send_notifications else "--quiet",
         s3_dst=lambda wildcards: config["upload"].get(wildcards.data_provenance, {}).get("s3_dst", ""),
-        cloudfront_domain=lambda wildcards: config["upload"].get(wildcards.data_provenance, {}).get("cloudfront_domain", "")
     shell:
         """
-        ./ingest/bin/upload-to-s3 \
+        ./bin/nextstrain-remote-upload-with-slack-notification \
             {params.quiet} \
-            {input.model_results:q} \
-            {params.s3_dst:q}/nextstrain_clades/{wildcards.geo_resolution:q}/{wildcards.model:q}/latest_results.json.gz \
-            {params.cloudfront_domain} 2>&1 | tee {output.upload_flag}
+            {params.s3_dst:q}/nextstrain_clades/{wildcards.geo_resolution:q}/{wildcards.model:q}/ \
+            {input.model_results}
         """


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->
- Move all uploaded files to the public S3 bucket
- Upload gzip model results to be browser friendly
- Upload model results as `latest_results.json` for viz app to easily fetch the latest results
- Add clade type to model results S3 prefix

See updated READMEs for the full list of updated addresses. 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Trial [case counts GH Action](https://github.com/nextstrain/forecasts-ncov/actions/runs/3745286766) 
- [x] Trial [GISAID clade counts GH Action](https://github.com/nextstrain/forecasts-ncov/actions/runs/3745269044)
- [x] Trial [open clade counts GH Action](https://github.com/nextstrain/forecasts-ncov/actions/runs/3745270480)
- [x] Trial model runs on AWS Batch (`26881f06-3468-4b44-bef2-c7dabc63cde6`)
    - I copied over results from trial counts runs to the new addresses before running the model workflow
    - Results will be available at:
        - `s3://nextstrain-data/files/workflows/forecasts-ncov/open/trial/config-latest-results/nextstrain_clades/<geo_resolution>/<model>/latest_results.json.gz`
        - `s3://nextstrain-data/files/workflows/forecasts-ncov/gisaid/trial/config-latest-results/nextstrain_clades/<geo_resolution>/<model>/latest_results.json.gz`
   


<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
