### PR TITLE
Adding pivot variable to config

### DIFF
--- a/config/mlr-config.yaml
+++ b/config/mlr-config.yaml
@@ -13,6 +13,7 @@ settings:
 
 model:
   generation_time: 4.8
+  pivot: "21L (Omicron)"
 
 inference:
   method: "FullRank"

--- a/config/renewal-config.yaml
+++ b/config/renewal-config.yaml
@@ -21,6 +21,7 @@ model:
   prior_seq_dispersion: 100.0 # Ignored if using Multinomial
   k: 12 # Number of spline knots to use
   order: 4 # Order of spline to use
+  pivot: "21L (Omicron)"
   generation_time: # Specify mean and standard deviation for generation time
     Delta:
       name: "Delta"

--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -102,7 +102,7 @@ class MLRConfig:
         return fit, save, load, export_json, export_path
 
 
-def fit_models(rs, locations, model, inference_method, path, save):
+def fit_models(rs, locations, model, inference_method, path, save, pivot=None):
     multi_posterior = ef.MultiPosterior()
 
     for location in locations:
@@ -114,7 +114,7 @@ def fit_models(rs, locations, model, inference_method, path, save):
             print(f"Location {location} not in data")
             continue
 
-        data = ef.VariantFrequencies(raw_seq=raw_seq)
+        data = ef.VariantFrequencies(raw_seq=raw_seq, pivot=pivot)
 
         # Fit model
         posterior = inference_method.fit(model, data, name=location)
@@ -237,6 +237,7 @@ if __name__ == "__main__":
             inference_method,
             export_path,
             save,
+            pivot=config.config["model"]["pivot"]
         )
     elif load:
         print("Loading results")

--- a/scripts/run-renewal-model.py
+++ b/scripts/run-renewal-model.py
@@ -225,7 +225,7 @@ def check_generation_times(rs, model):
     return None
 
 
-def fit_models(rc, rs, locations, model, inference_method, path, save):
+def fit_models(rc, rs, locations, model, inference_method, path, save, pivot=None):
     multi_posterior = ef.MultiPosterior()
 
     check_generation_times(rs, model)
@@ -241,7 +241,11 @@ def fit_models(rc, rs, locations, model, inference_method, path, save):
             continue
 
         # Define data object
-        data = ef.CaseFrequencyData(raw_cases=raw_cases, raw_seq=raw_seq)
+        data = ef.CaseFrequencyData(
+            raw_cases=raw_cases,
+            raw_seq=raw_seq,
+            pivot=pivot
+        )
 
         # Fit model
         posterior = inference_method.fit(model, data, name=location)
@@ -354,6 +358,7 @@ if __name__ == "__main__":
             inference_method,
             export_path,
             save,
+            pivot=config.config["model"]["pivot"]
         )
     elif load:
         print("Loading results")


### PR DESCRIPTION
### Description of proposed changes

This PR allows configs to specify which variant is being used to compute growth advantages. This will make this variant have a growth advantage of 1 when exported.