### PR TITLE
update-*-clade-counts: use `--freeze-installed`

### DIFF
--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -35,7 +35,7 @@ jobs:
         activate-environment: counts
 
     - name: setup
-      run: mamba install "pandas>=1.0.0" "tsv-utils"
+      run: mamba install "pandas>=1.0.0" "tsv-utils" --freeze-installed
 
     - name: download metadata
       run: ./ingest/bin/download-from-s3 s3://nextstrain-ncov-private/metadata.tsv.gz metadata.tsv

--- a/.github/workflows/update-ncov-open-clade-counts.yaml
+++ b/.github/workflows/update-ncov-open-clade-counts.yaml
@@ -36,7 +36,7 @@ jobs:
         activate-environment: counts
 
     - name: setup
-      run: mamba install "pandas>=1.0.0" "tsv-utils"
+      run: mamba install "pandas>=1.0.0" "tsv-utils" --freeze-installed
 
     - name: download metadata
       run: ./ingest/bin/download-from-s3 s3://nextstrain-data/files/ncov/open/metadata.tsv.gz metadata.tsv


### PR DESCRIPTION
Prevents Mamba from using PyPy instead of CPython to use the build 1 of pandas 1.5.2 on conda-forge. Using PyPy caused the GISAID clade counts job to fail with a cryptic message "The operation was canceled."¹

¹ https://github.com/nextstrain/forecasts-ncov/actions/runs/3859902846

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Test [GISAID clade counts action](https://github.com/nextstrain/forecasts-ncov/actions/runs/3878546875) completes successfully

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
