### PR TITLE
fix: Add `--cores` to gh actions nextstrain build

### DIFF
--- a/.github/workflows/run-models.yaml
+++ b/.github/workflows/run-models.yaml
@@ -71,4 +71,5 @@ jobs:
             envdir env.d snakemake \
               --configfile config/config.yaml optional.yaml \
               --printshellcmds \
+              --cores 8 \
               "${override_config[@]}"


### PR DESCRIPTION
This is required for the action to be compatible with snakemake version >5.11.0
which started to require the `--cores` option

For more context see:
- https://github.com/nextstrain/cli/issues/272 
- https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1681324279363569?thread_ts=1681293140.124269&cid=C01LCTT7JNN

- [ ] Test run: https://github.com/nextstrain/forecasts-ncov/actions/runs/4682609939/jobs/8296675794