### PR TITLE
Add 23B (Omicron) variant

### DIFF
--- a/config/renewal-config.yaml
+++ b/config/renewal-config.yaml
@@ -73,6 +73,11 @@ model:
       mean: 3.1
       sd: 1.2
       family: "Gamma" # Options: Gamma and LogNormal
+    O23B:
+      name: "23B (Omicron)"
+      mean: 3.1
+      sd: 1.2
+      family: "Gamma" # Options: Gamma and LogNormal
     other:
       name: "other"
       mean: 4.4

--- a/defaults/clade_to_variant.tsv
+++ b/defaults/clade_to_variant.tsv
@@ -11,3 +11,4 @@ clade	variant
 22E (Omicron)	22E (Omicron)
 22F (Omicron)	22F (Omicron)
 23A (Omicron)	23A (Omicron)
+23B (Omicron)	23B (Omicron)

--- a/viz/src/config.js
+++ b/viz/src/config.js
@@ -6,13 +6,14 @@ export const config = {
   variantColors: new Map([
     ["other", "#737373"],
     ["21L (Omicron)", "#BDBDBD"],
-    ["22A (Omicron)", "#447CCD"],
-    ["22B (Omicron)", "#5EA9A1"],
-    ["22C (Omicron)", "#8ABB6A"],
-    ["22D (Omicron)", "#BEBB48"],
-    ["22E (Omicron)", "#E29E39"],
-    ["22F (Omicron)", "#E2562B"],
-    ["23A (Omicron)", "#FF322C"],
+    ["22A (Omicron)", "#7725c6"],
+    ["22B (Omicron)", "#447CCD"],
+    ["22C (Omicron)", "#5EA9A1"],
+    ["22D (Omicron)", "#8ABB6A"],
+    ["22E (Omicron)", "#BEBB48"],
+    ["22F (Omicron)", "#E29E39"],
+    ["23A (Omicron)", "#E2562B"],
+    ["23B (Omicron)", "#FF322C"],
   ]),
   variantDisplayNames: new Map([
     ["other", "other"],
@@ -24,5 +25,6 @@ export const config = {
     ["22E (Omicron)", "22E (BQ.1)"],
     ["22F (Omicron)", "22F (XBB)"],
     ["23A (Omicron)", "23A (XBB.1.5)"],
+    ["23B (Omicron)", "23B (XBB.1.16)"],
   ])
 }


### PR DESCRIPTION
### Description of proposed changes

Adds new variant elevated in https://github.com/nextstrain/ncov/pull/1059

Includes adding the variant to model configs.
Updates the hardcoded color and display name maps for the viz app. Changed 21A to a purple color (#7725c6) and shifted the colors for all other variants so that the latest variant is the bright red color (#FF322C).

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
