### PR TITLE
Add workflow to deploy viz app to GH pages

### DIFF
--- a/.github/workflows/deploy-viz-app.yaml
+++ b/.github/workflows/deploy-viz-app.yaml
@@ -1,0 +1,51 @@
+name: Deploy Viz App to GitHub Pages
+
+on:
+  push:
+    branches: ['main']
+    paths: ['viz/*']
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci --prefix viz/
+
+      - name: Build
+        run: npm run build --prefix viz/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload the Vite build output
+          path: './viz/dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/viz/vite.config.js
+++ b/viz/vite.config.js
@@ -3,5 +3,8 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // The base must match repo name since we are deploying the site to https://nextstrain.github.io/forecasts-ncov/
+  // See vite docs on deploying to GH pages: https://vitejs.dev/guide/static-deploy.html#github-pages
+  base: "/forecasts-ncov/",
   plugins: [react()],
 })


### PR DESCRIPTION
### Description of proposed changes

Adds a workflow based on the example GH Action workflow shown in the Vite docs¹ for deploying to GH pages.

Includes a small modification to viz/vite.config.js to ensure the base of the assets produced matches the expected URL for the page.

¹ https://vitejs.dev/guide/static-deploy.html#github-pages

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
