### PR TITLE
Summarize lineage counts

### DIFF
--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -91,15 +91,16 @@ jobs:
     - name: upload clade counts
       run: |
         S3_DST=s3://nextstrain-data/files/workflows/forecasts-ncov/gisaid
+        CLOUDFRONT_DOMAIN="data.nextstrain.org"
 
         if [[ "$TRIAL_NAME" ]]; then
           S3_DST+=/trial/"$TRIAL_NAME"
         fi
 
-        ./ingest/bin/upload-to-s3 global_clade_counts.tsv "$S3_DST"/nextstrain_clades/global.tsv.gz
-        ./ingest/bin/upload-to-s3 global_lineage_counts.tsv "$S3_DST"/pango_lineages/global.tsv.gz
-        ./ingest/bin/upload-to-s3 us_clade_counts.tsv "$S3_DST"/nextstrain_clades/usa.tsv.gz
-        ./ingest/bin/upload-to-s3 us_lineage_counts.tsv "$S3_DST"/pango_lineages/usa.tsv.gz        
+        ./ingest/bin/upload-to-s3 global_clade_counts.tsv "$S3_DST"/nextstrain_clades/global.tsv.gz "$CLOUDFRONT_DOMAIN"
+        ./ingest/bin/upload-to-s3 global_lineage_counts.tsv "$S3_DST"/pango_lineages/global.tsv.gz "$CLOUDFRONT_DOMAIN"
+        ./ingest/bin/upload-to-s3 us_clade_counts.tsv "$S3_DST"/nextstrain_clades/usa.tsv.gz "$CLOUDFRONT_DOMAIN"
+        ./ingest/bin/upload-to-s3 us_lineage_counts.tsv "$S3_DST"/pango_lineages/usa.tsv.gz "$CLOUDFRONT_DOMAIN"
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: subset metadata columns
       run: |
         tsv-select -H \
-          -f strain,date,country,division,QC_overall_status,Nextstrain_clade \
+          -f strain,date,country,division,QC_overall_status,Nextstrain_clade,Nextclade_pango \
           metadata.tsv > metadata_pruned.tsv
 
         mv metadata_pruned.tsv metadata.tsv
@@ -59,6 +59,15 @@ jobs:
           --filter-query "QC_overall_status != 'bad'" \
           --output global_clade_counts.tsv
 
+    - name: summarize global lineage counts
+      run: |
+        ./ingest/bin/summarize-clade-sequence-counts \
+          --metadata metadata.tsv \
+          --clade-column Nextclade_pango \
+          --filter-columns QC_overall_status \
+          --filter-query "QC_overall_status != 'bad'" \
+          --output global_lineage_counts.tsv
+
     - name: summarize us clade counts
       run: |
         ./ingest/bin/summarize-clade-sequence-counts \
@@ -69,6 +78,16 @@ jobs:
           --filter-query "QC_overall_status != 'bad' & country == 'USA'" \
           --output us_clade_counts.tsv
 
+    - name: summarize us lineage counts
+      run: |
+        ./ingest/bin/summarize-clade-sequence-counts \
+          --metadata metadata.tsv \
+          --location-column division \
+          --clade-column Nextclade_pango \
+          --filter-columns QC_overall_status country \
+          --filter-query "QC_overall_status != 'bad' & country == 'USA'" \
+          --output us_lineage_counts.tsv
+
     - name: upload clade counts
       run: |
         S3_DST=s3://nextstrain-data/files/workflows/forecasts-ncov/gisaid
@@ -78,7 +97,9 @@ jobs:
         fi
 
         ./ingest/bin/upload-to-s3 global_clade_counts.tsv "$S3_DST"/nextstrain_clades/global.tsv.gz
+        ./ingest/bin/upload-to-s3 global_lineage_counts.tsv "$S3_DST"/pango_lineages/global.tsv.gz
         ./ingest/bin/upload-to-s3 us_clade_counts.tsv "$S3_DST"/nextstrain_clades/usa.tsv.gz
+        ./ingest/bin/upload-to-s3 us_lineage_counts.tsv "$S3_DST"/pango_lineages/usa.tsv.gz        
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/update-ncov-open-clade-counts.yaml
+++ b/.github/workflows/update-ncov-open-clade-counts.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: subset metadata columns
       run: |
         tsv-select -H \
-          -f strain,date,country,division,QC_overall_status,Nextstrain_clade \
+          -f strain,date,country,division,QC_overall_status,Nextstrain_clade,Nextclade_pango \
           metadata.tsv > metadata_pruned.tsv
 
         mv metadata_pruned.tsv metadata.tsv
@@ -60,6 +60,15 @@ jobs:
           --filter-query "QC_overall_status != 'bad'" \
           --output global_clade_counts.tsv
 
+    - name: summarize global lineage counts
+      run: |
+        ./ingest/bin/summarize-clade-sequence-counts \
+          --metadata metadata.tsv \
+          --clade-column Nextclade_pango \
+          --filter-columns QC_overall_status \
+          --filter-query "QC_overall_status != 'bad'" \
+          --output global_lineage_counts.tsv
+
     - name: summarize us clade counts
       run: |
         ./ingest/bin/summarize-clade-sequence-counts \
@@ -69,6 +78,16 @@ jobs:
           --filter-columns QC_overall_status country \
           --filter-query "QC_overall_status != 'bad' & country == 'USA'" \
           --output us_clade_counts.tsv
+
+    - name: summarize us lineage counts
+      run: |
+        ./ingest/bin/summarize-clade-sequence-counts \
+          --metadata metadata.tsv \
+          --location-column division \
+          --clade-column Nextclade_pango \
+          --filter-columns QC_overall_status country \
+          --filter-query "QC_overall_status != 'bad' & country == 'USA'" \
+          --output us_lineage_counts.tsv
 
     - name: upload clade counts
       run: |
@@ -80,7 +99,9 @@ jobs:
         fi
 
         ./ingest/bin/upload-to-s3 global_clade_counts.tsv "$S3_DST"/nextstrain_clades/global.tsv.gz $CLOUDFRONT_DOMAIN
+        ./ingest/bin/upload-to-s3 global_lineage_counts.tsv "$S3_DST"/pango_lineages/global.tsv.gz $CLOUDFRONT_DOMAIN
         ./ingest/bin/upload-to-s3 us_clade_counts.tsv "$S3_DST"/nextstrain_clades/usa.tsv.gz $CLOUDFRONT_DOMAIN
+        ./ingest/bin/upload-to-s3 us_lineage_counts.tsv "$S3_DST"/pango_lineages/usa.tsv.gz $CLOUDFRONT_DOMAIN
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -35,8 +35,12 @@ Within TSVs at the country resolution, the `location` column contains divisions 
 | --------------- | ----------------- | --------------------- | ------------------------------------------------------------------------------------------------- |
 | GISAID          | Nextstrain clades | Global                | https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/global.tsv.gz |
 |                 |                   | USA                   | https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/usa.tsv.gz    |
+|                 | Pango lineages    | Global                | https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/pango_lineages/global.tsv.gz |
+|                 |                   | USA                   | https://data.nextstrain.org/files/workflows/forecasts-ncov/gisaid/pango_lineages/usa.tsv.gz    |
 | open (GenBank)  | Nextstrain clades | Global                | https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/global.tsv.gz   |
 |                 |                   | USA                   | https://data.nextstrain.org/files/workflows/forecasts-ncov/open/nextstrain_clades/usa.tsv.gz      |
+|                 | Pango lineages    | Global                | https://data.nextstrain.org/files/workflows/forecasts-ncov/open/pango_lineages/global.tsv.gz |
+|                 |                   | USA                   | https://data.nextstrain.org/files/workflows/forecasts-ncov/open/pango_lineages/usa.tsv.gz    |
 
 ## Running locally
 


### PR DESCRIPTION
### Description of proposed changes

Ahead of further work on forecasting (collapsed) Pango lineages, I wanted to get lineage counts in order for work downstream.

This commit mirrors the clade count mechanism to summarize Pango lineages as well using the `Nextclade_pango` metadata column. This applies to both GISAID and open data, as well as to both global and USA.

I believe these lineage counts will be automatically provisioned by GitHub Actions once this PR is merged.

### Testing

I've tested locally.

- [x] Checks pass


