### PR TITLE
Switch to 22B (BA.5) baseline and force inclusion of 23B

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,7 +16,7 @@ prepare_data:
       location_min_seq_days: 30
       excluded_locations: "defaults/global_excluded_locations.txt"
       prune_seq_days: 12
-      clade_min_seq: 4000
+      clade_min_seq: 5000
       clade_min_seq_days: 150
       clade_to_variant: "defaults/clade_to_variant.tsv"
   open:
@@ -26,7 +26,7 @@ prepare_data:
       location_min_seq_days: 30
       excluded_locations: "defaults/global_excluded_locations.txt"
       prune_seq_days: 12
-      clade_min_seq: 4000
+      clade_min_seq: 5000
       clade_min_seq_days: 150
       clade_to_variant: "defaults/clade_to_variant.tsv"
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,6 +19,7 @@ prepare_data:
       clade_min_seq: 5000
       clade_min_seq_days: 150
       clade_to_variant: "defaults/clade_to_variant.tsv"
+      force_include_clades: "'23B (Omicron)=23B (Omicron)'"
   open:
     global:
       included_days: 150
@@ -29,6 +30,7 @@ prepare_data:
       clade_min_seq: 5000
       clade_min_seq_days: 150
       clade_to_variant: "defaults/clade_to_variant.tsv"
+      force_include_clades: "'23B (Omicron)=23B (Omicron)'"
 
 # Model configs
 renewal_config: "config/renewal-config.yaml"

--- a/config/mlr-config.yaml
+++ b/config/mlr-config.yaml
@@ -13,7 +13,7 @@ settings:
 
 model:
   generation_time: 4.8
-  pivot: "21L (Omicron)"
+  pivot: "22B (Omicron)"
 
 inference:
   method: "NUTS"

--- a/config/renewal-config.yaml
+++ b/config/renewal-config.yaml
@@ -21,7 +21,7 @@ model:
   prior_seq_dispersion: 100.0 # Ignored if using Multinomial
   k: 12 # Number of spline knots to use
   order: 4 # Order of spline to use
-  pivot: "21L (Omicron)"
+  pivot: "22B (Omicron)"
   generation_time: # Specify mean and standard deviation for generation time
     Delta:
       name: "Delta"

--- a/viz/src/config.js
+++ b/viz/src/config.js
@@ -8,23 +8,17 @@ const mlrUrl = `${DEFAULT_ENDPOINT_PREFIX}/mlr/latest_results.json`;
 const renewalUrl = `${DEFAULT_ENDPOINT_PREFIX}/renewal/latest_results.json`;
 
 const variantColors = new Map([
-  ["other", "#737373"],
-  ["21L (Omicron)", "#BDBDBD"],
-  ["22A (Omicron)", "#7725c6"],
-  ["22B (Omicron)", "#447CCD"],
-  ["22C (Omicron)", "#5EA9A1"],
-  ["22D (Omicron)", "#8ABB6A"],
-  ["22E (Omicron)", "#BEBB48"],
-  ["22F (Omicron)", "#E29E39"],
-  ["23A (Omicron)", "#E2562B"],
-  ["23B (Omicron)", "#FF322C"],
+  ["other", "#595959"],
+  ["22B (Omicron)", "#A6A6A6"],
+  ["22D (Omicron)", "#4D21AD"],
+  ["22E (Omicron)", "#4C90C0"],
+  ["22F (Omicron)", "#8EBC66"],
+  ["23A (Omicron)", "#DEA73C"],
+  ["23B (Omicron)", "#DB2823"],
 ]);
 const variantDisplayNames = new Map([
   ["other", "other"],
-  ["21L (Omicron)", "21L (BA.2)"],
-  ["22A (Omicron)", "22A (BA.4)"],
   ["22B (Omicron)", "22B (BA.5)"],
-  ["22C (Omicron)", "22C (BA.2.12.1)"],
   ["22D (Omicron)", "22D (BA.2.75)"],
   ["22E (Omicron)", "22E (BQ.1)"],
   ["22F (Omicron)", "22F (XBB)"],


### PR DESCRIPTION
### Description of proposed changes

21L (BA.2) is now getting excluded by our count threshold. This should be making the MLR model non-identifiable, because there isn't the pivot in the data. This PR updates pivot to 22B and also cleans update color ramp to remove unused clades.

Additionally, this PR force includes clade 23B as this wasn't hitting the clade count threshold.

### Testing

Tested locally.

- [x] Checks pass
