### PR TITLE
Fix trigger for static images

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -32,6 +32,13 @@ def get_todays_date():
     date = datetime.today().strftime('%Y-%m-%d')
     return date
 
+# Check which models to run based on which model configs have been provided
+models_to_run = [
+    model_name
+    for model_name in KNOWN_MODELS
+    if config.get(f"{model_name}_config")
+]
+
 def _get_all_input(w):
     data_provenances = config["data_provenances"] if isinstance(config["data_provenances"], list) else [config["data_provenances"]]
     variant_classifications = config["variant_classifications"] if isinstance(config["variant_classifications"], list) else [config["variant_classifications"]]
@@ -50,13 +57,6 @@ def _get_all_input(w):
             variant_classification=variant_classifications,
             geo_resolution=geo_resolutions
         )
-    ]
-
-    # Check which models to run based on which model configs have been provided
-    models_to_run = [
-        model_name
-        for model_name in KNOWN_MODELS
-        if config.get(f"{model_name}_config")
     ]
 
     if models_to_run:
@@ -82,10 +82,8 @@ def _get_all_input(w):
                 date=run_date
             ))
 
-            if (config.get("trigger_static_model_viz", False) and
-                all(required_model in models_to_run for required_model in ["mlr", "renewal"])):
-                # Trigger for static model viz which uses both MLR and renewal model outputs
-                # Currently we only support gisaid/global model results
+            if config.get("trigger_static_model_viz", False):
+                # Currently we only support gisaid/nextstrain_clades/global model results
                 all_input.extend(expand(
                     "results/{data_provenance}/{variant_classification}/{geo_resolution}/{date}_trigger_static_model_viz.done",
                     data_provenance=[data_provenance for data_provenance in data_provenances if data_provenance == "gisaid"],

--- a/workflow/snakemake_rules/trigger.smk
+++ b/workflow/snakemake_rules/trigger.smk
@@ -1,13 +1,20 @@
 """
 This part of the workflow triggers downstream GitHub Action workflows.
+
+Requires `models_to_run` variable to be defined upstream.
 """
 
+def _get_trigger_static_model_viz_input(wildcards):
+    return [
+        f"results/gisaid/nextstrain_clades/global/{model}/{wildcards.date}_latest_results_s3_upload.done"
+        for model in models_to_run
+    ]
+
+
 rule trigger_static_model_viz:
-    input:
-        latest_renewal_upload_flag = "results/gisaid/global/renewal/{date}_latest_results_s3_upload.done",
-        latest_mlr_upload_flag = "results/gisaid/global/mlr/{date}_latest_results_s3_upload.done",
+    input: _get_trigger_static_model_viz_input
     output:
-        touch("results/gisaid/global/{date}_trigger_static_model_viz.done")
+        touch("results/gisaid/nextstrain_clades/global/{date}_trigger_static_model_viz.done")
     shell:
         """
         ./bin/trigger forecasts-ncov static-model-viz


### PR DESCRIPTION
### Description of proposed changes

Since we stopped running the renewal models in https://github.com/nextstrain/forecasts-ncov/pull/34, the check that all required models are included fails and the static image workflow has not been running in our automated workflows. The last automated run of the static image workflow was 2023-04-23.¹

This commit removes the extra check for required models since the MLR and renewal data are now handled separately in the viz components.² This also adds a new function to generate the inputs dynamically for the rule `trigger_static_model_viz`. This ensures that we wait on results from both models if we decide to run the renewal models again.

¹ https://github.com/nextstrain/forecasts-ncov/actions/runs/4781440942 ² https://github.com/nextstrain/forecasts-viz/pull/3

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Verified the trigger rule is included in DAG with Snakemake's `-n` flag

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
