### PR TITLE
Support hierarchical models

### DIFF
--- a/config/mlr-config.yaml
+++ b/config/mlr-config.yaml
@@ -14,6 +14,7 @@ settings:
 model:
   generation_time: 4.8
   pivot: "23A (Omicron)"
+  hierarchical: true
 
 inference:
   method: "NUTS"

--- a/config/mlr-config.yaml
+++ b/config/mlr-config.yaml
@@ -15,7 +15,6 @@ model:
   generation_time: 4.8
   pivot: "23A (Omicron)"
   hierarchical: true
-  pool_scale: 1.0
 
 inference:
   method: "NUTS"

--- a/config/mlr-config.yaml
+++ b/config/mlr-config.yaml
@@ -15,6 +15,7 @@ model:
   generation_time: 4.8
   pivot: "23A (Omicron)"
   hierarchical: true
+  pool_scale: 1.0
 
 inference:
   method: "NUTS"

--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -284,6 +284,12 @@ if __name__ == "__main__":
         "--pivot",
         help="Variant to use as pivot. Overrides model.pivot in config.",
     )
+
+    parser.add_argument(
+        "--hier",
+        help="Whether to run the model as hierarchical. Overrides model.hierarchical in config. "
+        + "Default is false if unspecified."
+    )
     args = parser.parse_args()
 
     # Load configuration, data, and create model
@@ -317,7 +323,12 @@ if __name__ == "__main__":
     print("pivot", pivot)
 
     # Fit or load model results
-    hier = config.config["model"]["hierarchical"] or False
+    hier = False
+    if config.config["model"]["hierarchical"]:
+        hier = config.config["model"]["pivot"]
+    if args.hier:
+        hier = args.hier
+    print("hierarchical", hier)
 
     if fit:
         print("Fitting model")

--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -31,7 +31,7 @@ class NUTS_from_MAP:
         self.lr = lr
 
     def fit(self, model, data, name=None):
-        init_strat, _ = ef.init_to_MAP(model, data, iters=30_000, lr=self.lr)
+        init_strat, _ = ef.init_to_MAP(model, data, iters=self.iters, lr=self.lr)
         inference_method = ef.InferNUTS(
             num_warmup=self.num_warmup,
             num_samples=self.num_samples,

--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -137,7 +137,7 @@ def fit_models(rs, locations, model, inference_method, hier, path, save, pivot=N
     multi_posterior = ef.MultiPosterior()
 
     if hier:
-        # Subset data to lo of interest
+        # Subset data to locations of interest
         raw_seq = rs[rs.location.isin(locations)]
         data = ef.HierFrequencies(raw_seq=raw_seq, pivot=pivot, group="location")
 
@@ -328,6 +328,8 @@ if __name__ == "__main__":
 
     mlr_model, hier = config.load_model(override_hier=override_hier)
     print("Model created.")
+
+    print("hierarchical:", hier)
 
     inference_method = config.load_optim()
     print("Inference method defined.")

--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -35,7 +35,8 @@ class NUTS_from_MAP:
         inference_method = ef.InferNUTS(
             num_warmup=self.num_warmup,
             num_samples=self.num_samples,
-            init_strategy=init_strat
+            init_strategy=init_strat,
+            dense_mass=True,
         )
         return inference_method.fit(model, data, name=name)
 
@@ -136,7 +137,7 @@ def fit_models(rs, locations, model, inference_method, hier, path, save, pivot=N
     multi_posterior = ef.MultiPosterior()
 
     if hier:
-        # Subset data to locations of interest
+        # Subset data to lo of interest
         raw_seq = rs[rs.location.isin(locations)]
         data = ef.HierFrequencies(raw_seq=raw_seq, pivot=pivot, group="location")
 

--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -9,7 +9,6 @@ import json
 import evofr as ef
 from datetime import date
 
-
 def parse_with_default(cf, var, dflt):
     if var in cf:
         return cf[var]
@@ -17,11 +16,13 @@ def parse_with_default(cf, var, dflt):
         print(f"Using default value for {var}")
         return dflt
 
-
 def parse_generation_time(cf_m):
     tau = parse_with_default(cf_m, "generation_time", 4.8)
     return tau
 
+def parse_pool_scale(cf_m):
+    pool_scale = parse_with_default(cf_m, "pool_scale", 0.5)
+    return pool_scale
 
 class NUTS_from_MAP:
     def __init__(self, num_warmup, num_samples, iters, lr):
@@ -94,9 +95,13 @@ class MLRConfig:
         if override_hier is not None:
             hier = override_hier
 
+        print("hierarchical:", hier)
+
         # Processing likelihoods
         if hier:
-            model = ef.HierMLR(tau=tau)
+            ps = parse_pool_scale(model_cf)
+            print("Hierarchical pool scale:", ps)
+            model = ef.HierMLR(tau=tau, pool_scale=ps)
         else:
             model = ef.MultinomialLogisticRegression(tau=tau)
         model.forecast_L = forecast_L
@@ -328,8 +333,6 @@ if __name__ == "__main__":
 
     mlr_model, hier = config.load_model(override_hier=override_hier)
     print("Model created.")
-
-    print("hierarchical:", hier)
 
     inference_method = config.load_optim()
     print("Inference method defined.")

--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -124,8 +124,28 @@ class MLRConfig:
         return fit, save, load, export_json, export_path
 
 
-def fit_models(rs, locations, model, inference_method, path, save, pivot=None):
+
+
+def fit_models(rs, locations, model, inference_method, hier, path, save, pivot=None):
     multi_posterior = ef.MultiPosterior()
+
+    if hier:
+        # Subset data to locations of interest
+        raw_seq = rs[rs.location.isin(locations)]
+        data = ef.HierFrequencies(raw_seq=raw_seq, pivot=pivot, group="location")
+        
+        # Fit model
+        posterior = inference_method.fit(model, data, name="hierarchical")
+
+        #TODO: Add forecast method for these hierarchical models
+        n_days_to_present = (pd.to_datetime(date.today()) - data.dates[-1]).days
+        n_days_to_forecast = n_days_to_present + model.forecast_L
+        # model.forecast_frequencies(posterior.samples, forecast_L=n_days_to_forecast)
+
+        multi_posterior.add_posterior(posterior=posterior)
+
+        if save:
+            posterior.save_posterior(f"{path}/model/hierarchical.json")
 
     for location in locations:
         # Subset to data of interest
@@ -188,13 +208,39 @@ def make_model_directories(path):
     make_path_if_absent(path + "/models")
 
 
-def export_results(multi_posterior, ps, path, data_name):
+def export_results(multi_posterior, ps, path, data_name, hier):
     EXPORT_SITES = ["freq", "ga", "freq_forecast"]
     EXPORT_DATED = [True, False, True]
     EXPORT_FORECASTS = [False, False, True]
     EXPORT_ATTRS = ["pivot"]
     # Make directories
     make_model_directories(path)
+    
+    # Split hierarchical results into group posteriors
+    if hier:
+        def get_group_samples(samples, sites, group):
+            samples_group = dict()
+            for site in sites:
+                samples_group[site] = samples[site][..., group]
+            return samples_group
+
+        mp = multi_posterior
+        hier_samples = mp.locator["hierarchical"].samples
+        multi_posterior = ef.MultiPosterior()
+        for n, name in enumerate(mp.data.groups):
+            multi_posterior.add_posterior(
+                 ef.PosteriorHandler(
+                    samples=get_group_samples(hier_samples, EXPORT_SITES, n),
+                    data=mp.data.groups[n],
+                    name=name)
+            )
+        # Add final posterior for hierarchical growth advantages
+        multi_posterior.add_posterior(
+            ef.PosteriorHandler(
+                samples={"ga": hier_samples["ga_loc"]},
+                data=mp.data,
+                name="hierarchical")
+        )
 
     # Combine jsons from multiple model runs
     results = []
@@ -271,6 +317,8 @@ if __name__ == "__main__":
     print("pivot", pivot)
 
     # Fit or load model results
+    hier = config.config["model"]["hierarchical"] or False
+
     if fit:
         print("Fitting model")
         multi_posterior = fit_models(
@@ -278,6 +326,7 @@ if __name__ == "__main__":
             locations,
             mlr_model,
             inference_method,
+            hier,
             export_path,
             save,
             pivot=pivot
@@ -301,4 +350,4 @@ if __name__ == "__main__":
             config.config["settings"], "ps", dflt=[0.5, 0.8, 0.95]
         )
         data_name = args.data_name or config.config["data"]["name"]
-        export_results(multi_posterior, ps, export_path, data_name)
+        export_results(multi_posterior, ps, export_path, data_name, hier)

--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -21,7 +21,7 @@ def parse_generation_time(cf_m):
     return tau
 
 def parse_pool_scale(cf_m):
-    pool_scale = parse_with_default(cf_m, "pool_scale", 0.5)
+    pool_scale = parse_with_default(cf_m, "pool_scale", 0.1)
     return pool_scale
 
 class NUTS_from_MAP:

--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -133,7 +133,7 @@ def fit_models(rs, locations, model, inference_method, hier, path, save, pivot=N
         # Subset data to locations of interest
         raw_seq = rs[rs.location.isin(locations)]
         data = ef.HierFrequencies(raw_seq=raw_seq, pivot=pivot, group="location")
-        
+
         # Fit model
         posterior = inference_method.fit(model, data, name="hierarchical")
 
@@ -215,7 +215,7 @@ def export_results(multi_posterior, ps, path, data_name, hier):
     EXPORT_ATTRS = ["pivot"]
     # Make directories
     make_model_directories(path)
-    
+
     # Split hierarchical results into group posteriors
     if hier:
         def get_group_samples(samples, sites, group):
@@ -286,7 +286,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--hier",
+        "--hier",  action='store_true', default=False,
         help="Whether to run the model as hierarchical. Overrides model.hierarchical in config. "
         + "Default is false if unspecified."
     )
@@ -324,8 +324,8 @@ if __name__ == "__main__":
 
     # Fit or load model results
     hier = False
-    if config.config["model"]["hierarchical"]:
-        hier = config.config["model"]["pivot"]
+    if "hierarchical" in config.config["model"]:
+        hier = True
     if args.hier:
         hier = args.hier
     print("hierarchical", hier)

--- a/viz/src/App.jsx
+++ b/viz/src/App.jsx
@@ -25,7 +25,8 @@ function App() {
         <p>
           These plots show the estimated growth advantage for given clades relative to clade
           23A (lineage XBB.1.5). This describes how many more secondary infections a variant causes
-          on average relative to clade 23A. Vertical bars show the 95% HPD.
+          on average relative to clade 23A. Vertical bars show the 95% HPD. The "hierarchical" panel
+          shows pooled estimate of growth rates across different regions.
           Results last updated {mlrCladesData?.modelData?.get('updated') || 'loading'}.
         </p>
         <div id="cladeGrowthAdvantagePanel" class="panelDisplay">
@@ -35,7 +36,7 @@ function App() {
         <h2>Lineage frequencies over time</h2>
         <p>
           Each line represents the estimated frequency of a particular Pango lineage through time.
-          Lineages with fewer than 200 observations are collapsed into parental lineage.
+          Lineages with fewer than 350 observations are collapsed into parental lineage.
           Results last updated {mlrLineagesData?.modelData?.get('updated') || 'loading'}.
         </p>
         <div id="lineageFrequenciesPanel" class="panelDisplay">
@@ -47,6 +48,7 @@ function App() {
           These plots show the estimated growth advantage for given Pango lineages relative to
           lineage XBB.1.5. This describes how many more secondary infections a variant causes
           on average relative to lineage XBB.1.5. Vertical bars show the 95% HPD.
+          The "hierarchical" panel shows pooled estimate of growth rates across different regions.
           Results last updated {mlrLineagesData?.modelData?.get('updated') || 'loading'}.
         </p>
         <div id="lineageGrowthAdvantagePanel" class="panelDisplay">


### PR DESCRIPTION
## Description

Adding capacity to fit hierarchical MLR model. Currently, this can be done via either adding to the config file or as a command line argument. Will default to false if neither is provided.

This should export everything in the same format as previous model iterations, but will have an additional "hierarchical" location for the growth advantages which is essentially the mean growth advantages across all locations according to the model.

Things remaining:
- [x] Implement support for forecasts with the hierarchical model. ([PR Here](https://github.com/blab/evofr/pull/25))
- [x] Testing
