### PR TITLE
Replace "recombinant" clade with label "other"

### DIFF
--- a/scripts/prepare-data.py
+++ b/scripts/prepare-data.py
@@ -204,6 +204,9 @@ if __name__ == '__main__':
         # Replace variant with 'other' if they are not force included and do not meet the clade_min_seq requirement
         seq_counts.loc[~seq_counts['clade'].isin(force_included_clades | clades_with_min_seq), 'variant'] = 'other'
 
+    # Replace 'recombinant' clade with 'other'
+    seq_counts.loc[seq_counts['clade'].isin(['recombinant']), 'variant'] = 'other'
+
     # Add clades with unknown variants to 'other' variant group
     seq_counts.loc[pd.isna(seq_counts['variant']), 'variant'] = 'other'
 

--- a/tests/prepare_data/cram/01-cutoff-date.t
+++ b/tests/prepare_data/cram/01-cutoff-date.t
@@ -15,7 +15,7 @@ The output should include all clade counts, but create a subset of the case coun
   No min date was set, including all dates up to the max date.
   Only including locations that have at least 1 sequence(s) in the analysis date range.
   Locations that will be included: ['Argentina', 'Japan', 'USA', 'United Kingdom'].
-  Variants that will be included: ['19A', '20A', '20B', '20C', '20I', '21A', '21I', '21J', '21K', '21L', '21M', 'recombinant'].
+  Variants that will be included: ['19A', '20A', '20B', '20C', '20I', '21A', '21I', '21J', '21K', '21L', '21M', 'other'].
 
 Verify the header "clade" has been replaced by "variant".
 Verify that the output variants counts is the same as the original clade counts.

--- a/tests/prepare_data/cram/02-include-days.t
+++ b/tests/prepare_data/cram/02-include-days.t
@@ -17,7 +17,7 @@ The outputs should be subsets of the variants counts and case counts.
   Setting min date (inclusive) as '2022-01-06'.
   Only including locations that have at least 1 sequence(s) in the analysis date range.
   Locations that will be included: ['Argentina', 'Japan', 'USA', 'United Kingdom'].
-  Variants that will be included: ['19A', '20A', '20B', '20C', '20I', '21A', '21I', '21J', '21K', '21L', '21M', 'recombinant'].
+  Variants that will be included: ['19A', '20A', '20B', '20C', '20I', '21A', '21I', '21J', '21K', '21L', '21M', 'other'].
 
 Verify that the output variants counts is a subset with expected locations, variants, and dates.
 
@@ -26,7 +26,7 @@ Verify that the output variants counts is a subset with expected locations, vari
   $ echo $(tsv-select -H -f location "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort)
   Argentina Japan USA United Kingdom
   $ echo $(tsv-select -H -f variant "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort)
-  19A 20A 20B 20C 20I 21A 21I 21J 21K 21L 21M recombinant
+  19A 20A 20B 20C 20I 21A 21I 21J 21K 21L 21M other
   $ echo $(tsv-select -H -f date "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort | tsv-summarize --first 1 --last 1)
   2022-01-06 2022-01-10
 

--- a/tests/prepare_data/cram/03-prune-seq-days.t
+++ b/tests/prepare_data/cram/03-prune-seq-days.t
@@ -20,7 +20,7 @@ The outputs should be subsets of the variants counts and case counts.
   Only including locations that have at least 1 sequence(s) in the analysis date range.
   Locations that will be included: ['Argentina', 'Japan', 'USA', 'United Kingdom'].
   Pruning variants counts in the last 1 day(s) to exclude recent dates that may be overly enriched for variants.
-  Variants that will be included: ['19A', '20A', '20B', '20C', '20I', '21A', '21I', '21J', '21K', '21L', '21M', 'recombinant'].
+  Variants that will be included: ['19A', '20A', '20B', '20C', '20I', '21A', '21I', '21J', '21K', '21L', '21M', 'other'].
 
 Verify that the output variants counts is a subset with expected locations, variants, and dates.
 
@@ -29,7 +29,7 @@ Verify that the output variants counts is a subset with expected locations, vari
   $ echo $(tsv-select -H -f location "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort)
   Argentina Japan USA United Kingdom
   $ echo $(tsv-select -H -f variant "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort)
-  19A 20A 20B 20C 20I 21A 21I 21J 21K 21L 21M recombinant
+  19A 20A 20B 20C 20I 21A 21I 21J 21K 21L 21M other
   $ echo $(tsv-select -H -f date "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort | tsv-summarize --first 1 --last 1)
   2022-01-06 2022-01-09
 

--- a/tests/prepare_data/cram/04-location-min-seq.t
+++ b/tests/prepare_data/cram/04-location-min-seq.t
@@ -22,7 +22,7 @@ The outputs should be subsets of the clade counts and case counts.
   Only including locations that have at least 5000 sequence(s) in the analysis date range.
   Locations that will be included: ['Japan', 'USA', 'United Kingdom'].
   Pruning variants counts in the last 1 day(s) to exclude recent dates that may be overly enriched for variants.
-  Variants that will be included: ['19A', '20A', '20B', '20C', '20I', '21A', '21I', '21J', '21K', '21L', '21M', 'recombinant'].
+  Variants that will be included: ['19A', '20A', '20B', '20C', '20I', '21A', '21I', '21J', '21K', '21L', '21M', 'other'].
 
 Verify that the output clade counts is a subset with expected locations, clades, and dates.
 
@@ -31,7 +31,7 @@ Verify that the output clade counts is a subset with expected locations, clades,
   $ echo $(tsv-select -H -f location "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort)
   Japan USA United Kingdom
   $ echo $(tsv-select -H -f variant "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort)
-  19A 20A 20B 20C 20I 21A 21I 21J 21K 21L 21M recombinant
+  19A 20A 20B 20C 20I 21A 21I 21J 21K 21L 21M other
   $ echo $(tsv-select -H -f date "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort | tsv-summarize --first 1 --last 1)
   2022-01-06 2022-01-09
 

--- a/tests/prepare_data/cram/05-location-min-seq-days.t
+++ b/tests/prepare_data/cram/05-location-min-seq-days.t
@@ -23,7 +23,7 @@ The outputs should be subsets of the clade counts and case counts.
   Only including locations that have at least 5000 sequence(s) in the last 2 days of the analysis date range.
   Locations that will be included: ['USA', 'United Kingdom'].
   Pruning variants counts in the last 1 day(s) to exclude recent dates that may be overly enriched for variants.
-  Variants that will be included: ['19A', '20A', '20B', '20C', '20I', '21A', '21I', '21J', '21K', '21L', '21M', 'recombinant'].
+  Variants that will be included: ['19A', '20A', '20B', '20C', '20I', '21A', '21I', '21J', '21K', '21L', '21M', 'other'].
 
 Verify that the output clade counts is a subset with expected locations, clades, and dates.
 
@@ -32,7 +32,7 @@ Verify that the output clade counts is a subset with expected locations, clades,
   $ echo $(tsv-select -H -f location "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort)
   USA United Kingdom
   $ echo $(tsv-select -H -f variant "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort)
-  19A 20A 20B 20C 20I 21A 21I 21J 21K 21L 21M recombinant
+  19A 20A 20B 20C 20I 21A 21I 21J 21K 21L 21M other
   $ echo $(tsv-select -H -f date "$TMP/prepared_seq_counts.tsv" | tsv-uniq -H | tail -n +2 | sort | tsv-summarize --first 1 --last 1)
   2022-01-06 2022-01-09
 

--- a/tests/prepare_data/data/nextstrain_clades.tsv
+++ b/tests/prepare_data/data/nextstrain_clades.tsv
@@ -130,8 +130,8 @@ USA	21L	2022-01-08	25
 USA	21L	2022-01-09	21
 USA	21L	2022-01-10	27
 USA	21M	2022-01-02	1
-USA	recombinant	2022-01-02	1
-USA	recombinant	2022-01-10	1
+USA	other	2022-01-02	1
+USA	other	2022-01-10	1
 United Kingdom	19A	2022-01-03	4
 United Kingdom	20I	2022-01-08	1
 United Kingdom	20I	2022-01-09	1
@@ -173,4 +173,4 @@ United Kingdom	21L	2022-01-10	103
 United Kingdom	21M	2022-01-02	1
 United Kingdom	21M	2022-01-04	1
 United Kingdom	21M	2022-01-07	1
-United Kingdom	recombinant	2022-01-07	1
+United Kingdom	other	2022-01-07	1


### PR DESCRIPTION
### Description of proposed changes

With the rise of XBB viruses there are a large number of "recombinant" clades that no longer mean the same thing they used to. I think clearer and less noisy to just always collapse "recombinant" into the "other" category.

@joverlee521: I wasn't sure if you thought this needed more of a warning to users. I was basically trying to mirror how `NA` is replaced with `other`.

### Testing

Testing locally gives expected results:

![dropping-recombinant](https://github.com/nextstrain/forecasts-ncov/assets/1176109/080fd9f2-3a1e-42ea-b011-17b76e3d4fc2)

_Though looks like I need to fix tests. I'll look into this._

- [x] Checks pass
- [x] [Test run of cases workflow](https://github.com/nextstrain/forecasts-ncov/actions/runs/6712588605)


