### PR TITLE
Prepare data error

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -45,7 +45,7 @@ prepare_data:
     pango_lineages:
       global:
         included_days: 150
-        location_min_seq: 1500
+        location_min_seq: 1200
         location_min_seq_days: 30
         excluded_locations: "defaults/global_excluded_locations.txt"
         prune_seq_days: 12

--- a/scripts/prepare-data.py
+++ b/scripts/prepare-data.py
@@ -144,6 +144,10 @@ if __name__ == '__main__':
     locations_to_include = locations_with_min_seq - excluded_locations
     print(f"Locations that will be included: {sorted(locations_to_include)}.")
 
+    assert len(locations_to_include) > 0, \
+        "All locations have been excluded. Try again with different options, e.g. lowering the `--location-min-seq` cutoff.\n" + \
+        f"Here's a summary of available sequences per location:\n{seqs_per_location.to_dict(orient='records')}"
+
     ###########################################################################
     ############## Rules for collapsing clades to variants ####################
     ###########################################################################
@@ -234,7 +238,11 @@ if __name__ == '__main__':
         (seq_counts['location'].isin(locations_to_include))
     ]
 
-    print(f"Variants that will be included: {sorted(seq_counts['variant'].unique())}.")
+    included_variants = seq_counts['variant'].unique()
+    print(f"Variants that will be included: {sorted(included_variants)}.")
+
+    assert len(included_variants) > 0, \
+        "All variants have been excluded. Try again with different options, e.g. lowering the `--clade-min-seq` cutoff."
 
     # Sort variants subset and print to output file
     seq_counts.sort_values(['location', 'variant', 'date']) \


### PR DESCRIPTION
Add clear error messages for when the prepare-data output is empty. 
Lower the cutoff for open/pango-lineage sequences again to prevent errors.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
