### PR TITLE
Remove hierarchical location from frequency panel

### DIFF
--- a/viz/src/App.jsx
+++ b/viz/src/App.jsx
@@ -7,6 +7,9 @@ function App() {
   const mlrCladesData = useModelData(mlrCladesConfig);
   const mlrLineagesData = useModelData(mlrLineagesConfig);
 
+  const cladesLocationsFiltered = mlrCladesData?.modelData?.get('locations')?.filter((loc)=>loc!=='hierarchical') || [];
+  const lineagesLocationsFiltered = mlrCladesData?.modelData?.get('locations')?.filter((loc)=>loc!=='hierarchical') || [];
+
   return (
     <div className="App">
 
@@ -19,7 +22,7 @@ function App() {
           included. Results last updated {mlrCladesData?.modelData?.get('updated') || 'loading'}.
         </p>
         <div id="cladeFrequenciesPanel" class="panelDisplay"> {/* surrounding div(s) used for static-images.js script */}
-          <PanelDisplay data={mlrCladesData} params={{preset: "frequency"}}/>
+          <PanelDisplay data={mlrCladesData} locations={cladesLocationsFiltered} params={{preset: "frequency"}}/>
         </div>
 
         <h2>Clade growth advantage</h2>
@@ -42,7 +45,7 @@ function App() {
           included. Results last updated {mlrLineagesData?.modelData?.get('updated') || 'loading'}.
         </p>
         <div id="lineageFrequenciesPanel" class="panelDisplay">
-          <PanelDisplay data={mlrLineagesData} params={{preset: "frequency"}}/>
+          <PanelDisplay data={mlrLineagesData} locations={lineagesLocationsFiltered} params={{preset: "frequency"}}/>
         </div>
 
         <h2>Lineage growth advantage</h2>


### PR DESCRIPTION
The model viz is designed around showing a panel for each provided location (i.e. <json>.metadata.location), but provides an easy way for the calling component to define the specific list of locations instead.

The current data uses a hierarchical growth advantage model, which is defined as a new location but without any associated frequency data. Rather than modify the underlying viz library to exclude locations without any data for the requested graph (somewhat difficult given the library design), here I take the easy approach provide an explicit list of locations for the frequency panel.
