### PR TITLE
deploy-viz-app workflow: update path pattern

### DIFF
--- a/.github/workflows/deploy-viz-app.yaml
+++ b/.github/workflows/deploy-viz-app.yaml
@@ -3,7 +3,7 @@ name: Deploy Viz App to GitHub Pages
 on:
   push:
     branches: ['main']
-    paths: ['viz/*']
+    paths: ['viz/**']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Update path pattern to be recursive (i.e. match '/') by using double asterisks according to the GitHub Action filter docs.¹

@jameshadfield noticed the deploy workflow did not run when he merged https://github.com/nextstrain/forecasts-ncov/pull/51. This PR only updated a file within a subdirectory in `viz/` so the non-recursive path pattern did not match and thus did not trigger the workflow.

¹ https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet