### PR TITLE
workflow/run-models: pin nextstrain/base image

### DIFF
--- a/.github/workflows/run-models.yaml
+++ b/.github/workflows/run-models.yaml
@@ -63,7 +63,7 @@ jobs:
           --aws-batch \
           --detach \
           --no-download \
-          --image nextstrain/base \
+          --image nextstrain/base:build-20230720T001758Z \
           --cpus 8 \
           --memory 16GiB \
           --exec env \


### PR DESCRIPTION
The latest nextstrain/base image (triggered by the Augur v22.2.0 release) pulled in the latest release of jax v0.4.14¹ which included a breaking change that causes an error in evofr.²

Pinning the nextstrain/base image to an earlier version that used jax v0.4.13 that was able to run models without errors for now until evofr has been updated with a fix.

¹ https://github.com/nextstrain/docker-base/actions/runs/5718704119/job/15495059469#step:9:14762 
² https://github.com/blab/evofr/issues/28