### PR TITLE
Calculate weekly frequencies

### DIFF
--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -226,6 +226,9 @@ def make_raw_freq_tidy(data, location):
     variants = data.var_names
     date_map = data.date_to_index
 
+    # Calculate daily raw frequencies
+    daily_raw_freq = data.seq_counts / data.seq_counts.sum(axis=1)[:, None]
+
     # Calculate the 7-day moving sum for each of the clades
     kernel = np.ones(7)  # 7-day window
     numerator = np.apply_along_axis(lambda x: np.convolve(x, kernel, mode='same'), axis=0, arr=data.seq_counts)
@@ -235,13 +238,13 @@ def make_raw_freq_tidy(data, location):
     denominator = np.convolve(total_counts, kernel, mode='same')
 
     # Calculate the 7-day smoothed daily frequency
-    raw_freq = numerator / denominator[:, None]
+    weekly_raw_freq = numerator / denominator[:, None]
 
     # Create metadata
     metadata = {
         "dates": data.dates,
         "variants": data.var_names,
-        "sites": ["raw_freq"],
+        "sites": ["daily_raw_freq", "weekly_raw_freq"],
         "location": [location]
     }
 
@@ -251,14 +254,25 @@ def make_raw_freq_tidy(data, location):
         for day, d in date_map.items():
             entries.append({
                 "location": location,
-                "site": "raw_freq",
+                "site": "daily_raw_freq",
                 "variant": variant,
                 "date": day.strftime("%Y-%m-%d"),
                 "value": (
                     None
-                    if np.isnan(raw_freq[d, v])
-                    else np.around(raw_freq[d, v], decimals=3))
+                    if np.isnan(daily_raw_freq[d, v])
+                    else np.around(daily_raw_freq[d, v], decimals=3))
             })
+            entries.append({
+                "location": location,
+                "site": "weekly_raw_freq",
+                "variant": variant,
+                "date": day.strftime("%Y-%m-%d"),
+                "value": (
+                    None
+                    if np.isnan(weekly_raw_freq[d, v])
+                    else np.around(weekly_raw_freq[d, v], decimals=3))
+            })
+
     return {"metadata": metadata, "data": entries}
 
 


### PR DESCRIPTION
Rather than daily frequencies for `raw_freqs` use weekly frequencies instead.

With daily raw frequencies we have difficulty seeing patterns due to day-to-day measurement noise:

![daily-freqs](https://github.com/nextstrain/forecasts-ncov/assets/1176109/5600819f-8f63-48d6-a9a0-32efcd5b0557)

While with weekly frequencies, dynamics are much more clear:

![weekly-freqs](https://github.com/nextstrain/forecasts-ncov/assets/1176109/203a3b1f-dfcf-465d-89f3-fb8ebe7c3af5)

This is the same argument for why 7-day smoothed cases were clearer to look at than daily cases.

