### PR TITLE
.github/workflows: use vars.SLACK_CHANNELS as default

### DIFF
--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -10,7 +10,6 @@ on:
       slack_channel:
         description: 'Slack channel to push update alerts. Default channel is nextstrain-counts-updates.'
         required: false
-        default: 'nextstrain-counts-updates'
       trial_name:
         description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data/files/workflows/forecasts-ncov/gisaid'
         required: false
@@ -54,7 +53,7 @@ jobs:
           upload_all_sequence_counts \
           --config data_provenances=["gisaid"] s3_dst="$S3_DST"
       env: |
-        SLACK_CHANNELS: ${{ inputs.slack_channel }}
+        SLACK_CHANNELS: ${{ inputs.slack_channel || vars.SLACK_CHANNELS }}
         S3_DST: ${{ needs.set_s3_dst.outputs.s3_dst }}
 
   trigger_model_runs:

--- a/.github/workflows/update-ncov-open-clade-counts.yaml
+++ b/.github/workflows/update-ncov-open-clade-counts.yaml
@@ -11,7 +11,6 @@ on:
       slack_channel:
         description: 'Slack channel to push update alerts. Default channel is nextstrain-counts-updates.'
         required: false
-        default: 'nextstrain-counts-updates'
       trial_name:
         description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data/files/workflows/forecasts-ncov/open'
         required: false
@@ -55,7 +54,7 @@ jobs:
           upload_all_sequence_counts \
           --config data_provenances=["open"] s3_dst="$S3_DST"
       env: |
-        SLACK_CHANNELS: ${{ inputs.slack_channel }}
+        SLACK_CHANNELS: ${{ inputs.slack_channel || vars.SLACK_CHANNELS }}
         S3_DST: ${{ needs.set_s3_dst.outputs.s3_dst }}
 
   trigger_model_runs:


### PR DESCRIPTION
## Description of proposed changes
I keep forgetting that the workflow_dispatch.inputs default value is only applied when the workflow is triggered via a workflow dispatch. It does not get used when the workflow is triggered via the repository dispatch event in our automated triggers. This results in an empty slack channel value¹ so the upload messages cannot be sent to Slack.

Outside of this commit, I've set a repository level variable that is accessible via the `vars` context in the with block. This is used as the default value and the workflow_dispatch.input can continue to override it for trial runs.

¹ https://github.com/nextstrain/forecasts-ncov/actions/runs/6092447027/job/16530571876#step:5:13

## Related issue(s)

Follow up on https://github.com/nextstrain/forecasts-ncov/pull/60

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] verified [default slack channel used when input is empty](https://github.com/nextstrain/forecasts-ncov/actions/runs/6101239050/job/16557188352#step:5:14)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
