### PR TITLE
workflows/run-models: Unpin nextstrain-base image

### DIFF
--- a/.github/workflows/run-models.yaml
+++ b/.github/workflows/run-models.yaml
@@ -60,7 +60,7 @@ jobs:
           --aws-batch \
           --detach \
           --no-download \
-          --image nextstrain/base:build-20230720T001758Z \
+          --image nextstrain/base \
           --cpus 8 \
           --memory 16GiB \
           --env AWS_DEFAULT_REGION \


### PR DESCRIPTION
## Description of proposed changes
jax incompatibility issue in evofr¹ has been resolved in version 0.1.21 and the latest nextstrain-base image has been updated to include v0.1.21.²

¹ https://github.com/blab/evofr/issues/28
² https://github.com/nextstrain/docker-base/actions/runs/6332834776


## Related issue(s)

Resolves #57 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] [Test run](https://github.com/nextstrain/forecasts-ncov/actions/runs/6386683371)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
