### PR TITLE
fix: lineage_to_clade missed a `.`

### DIFF
--- a/scripts/modify-lineage-colours-and-order.py
+++ b/scripts/modify-lineage-colours-and-order.py
@@ -31,7 +31,7 @@ def lineage_to_clade(lineage, aliasor, fallback, clade_definitions):
         if clade_data['clade']=='other':
             continue
         comparison_lineage = aliasor.uncompress(clade_data['defining_lineage'])
-        if lineage_full == comparison_lineage or f"{lineage_full}.".startswith(comparison_lineage + "."):
+        if lineage_full == comparison_lineage or lineage_full.startswith(comparison_lineage + "."):
             return clade_data['clade']
     return fallback
 

--- a/scripts/modify-lineage-colours-and-order.py
+++ b/scripts/modify-lineage-colours-and-order.py
@@ -31,7 +31,7 @@ def lineage_to_clade(lineage, aliasor, fallback, clade_definitions):
         if clade_data['clade']=='other':
             continue
         comparison_lineage = aliasor.uncompress(clade_data['defining_lineage'])
-        if lineage_full == comparison_lineage or f"{lineage_full}.".startswith(comparison_lineage):
+        if lineage_full == comparison_lineage or f"{lineage_full}.".startswith("comparison_lineage" + "."):
             return clade_data['clade']
     return fallback
 

--- a/scripts/modify-lineage-colours-and-order.py
+++ b/scripts/modify-lineage-colours-and-order.py
@@ -31,7 +31,7 @@ def lineage_to_clade(lineage, aliasor, fallback, clade_definitions):
         if clade_data['clade']=='other':
             continue
         comparison_lineage = aliasor.uncompress(clade_data['defining_lineage'])
-        if lineage_full == comparison_lineage or f"{lineage_full}.".startswith("comparison_lineage" + "."):
+        if lineage_full == comparison_lineage or f"{lineage_full}.".startswith(comparison_lineage + "."):
             return clade_data['clade']
     return fallback
 


### PR DESCRIPTION
Previous logic made HK.34 belong to HK.3, because the "comparison_lineage" was missing a trailing `.` in `.startswith()`

I've tried to add a unit test but I couldn't figure out how to get vscode to import the functions in the script from outside the script.