### PR TITLE
ingest: restore CloudFront invalidation in upload

### DIFF
--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -87,3 +87,4 @@ open:
         --filter-query "QC_overall_status != 'bad' & country == 'USA'"
 
 s3_dst: s3://nextstrain-data/files/workflows/forecasts-ncov
+cloudfront_domain: 'data.nextstrain.org'

--- a/ingest/rules/sequence_counts.smk
+++ b/ingest/rules/sequence_counts.smk
@@ -63,10 +63,11 @@ rule upload_sequence_count:
         clade_seq_counts = "results/{data_provenance}/{variant_classification}/{geo_resolution}.tsv"
     output: touch("results/{data_provenance}/{variant_classification}/{geo_resolution}_upload.done")
     params:
-        s3_url = lambda w, input: _get_s3_url(w, input[0])
+        s3_url = lambda w, input: _get_s3_url(w, input[0]),
+        cloudfront_domain = config["cloudfront_domain"]
     benchmark:
         "benchmarks/{data_provenance}/{variant_classification}/{geo_resolution}/upload_sequence_counts.txt"
     shell:
         """
-        ./vendored/upload-to-s3 {input.clade_seq_counts} {params.s3_url:q}
+        ./vendored/upload-to-s3 {input.clade_seq_counts} {params.s3_url:q} {params.cloudfront_domain:q}
         """


### PR DESCRIPTION
## Description of proposed changes

The CloudFront domain arg for triggering CloudFront invalidation after upload was missed in my refactor of the GitHub Action workflow to a Snakemake workflow in 132355457c80ad9c0c5b9e5249e869e9b3485da9.

This restores the CloudFront invalidation so that the model runs will be able to always download the latest files.

Thank you @corneliusroemer for flagging the issue¹

¹ https://bedfordlab.slack.com/archives/C036L7V615F/p1705508089642509

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test run ](https://github.com/nextstrain/forecasts-ncov/actions/runs/7560141305)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
