### PR TITLE
Pin pandas<2.2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       run: python3 -m pip install cram
 
     - name: Install pandas and tsv-utils
-      run: mamba install "pandas>=1.0.0" "tsv-utils" "pango_aliasor>=0.3.0"
+      run: mamba install "pandas>=1.0.0,<2.2.0" "tsv-utils" "pango_aliasor>=0.3.0"
 
     - name: Run Cram tests
       run: cram --shell=/bin/bash tests/


### PR DESCRIPTION
Pandas 2.2.0 comes with deprecation warnings that are causing functional tests to fail on output checks.

    Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
    (to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
    but was not found to be installed on your system.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
