### PR TITLE
Update Pango lineage pivots to JN.1

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,14 +61,14 @@ models:
         pivot: "23A"
     pango_lineages:
       global:
-        pivot: "XBB.1.5"
+        pivot: "JN.1"
   open:
     nextstrain_clades:
       global:
         pivot: "23A"
     pango_lineages:
       global:
-        pivot: "XBB.1.5"
+        pivot: "JN.1"
 
 # Model configs
 mlr_config: "config/mlr-config.yaml"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -58,14 +58,14 @@ models:
   gisaid:
     nextstrain_clades:
       global:
-        pivot: "23A"
+        pivot: "23I"
     pango_lineages:
       global:
         pivot: "JN.1"
   open:
     nextstrain_clades:
       global:
-        pivot: "23A"
+        pivot: "23I"
     pango_lineages:
       global:
         pivot: "JN.1"

--- a/config/mlr-config.yaml
+++ b/config/mlr-config.yaml
@@ -13,7 +13,7 @@ settings:
 
 model:
   generation_time: 4.8
-  pivot: "23A"
+  pivot: "23I"
   hierarchical: true
 
 inference:

--- a/viz/src/App.jsx
+++ b/viz/src/App.jsx
@@ -41,8 +41,8 @@ function App() {
         <h2>Clade growth advantage</h2>
         <p>
           These plots show the estimated growth advantage for given clades relative to clade
-          23A (lineage XBB.1.5). This describes how many more secondary infections a variant causes
-          on average relative to clade 23A. Vertical bars show the 95% HPD. The "hierarchical" panel
+          23I (lineage BA.2.86). This describes how many more secondary infections a variant causes
+          on average relative to clade 23I. Vertical bars show the 95% HPD. The "hierarchical" panel
           shows pooled estimate of growth rates across different locations.
           Results last updated {mlrCladesData?.modelData?.get('updated') || 'loading'}.
         </p>

--- a/viz/src/App.jsx
+++ b/viz/src/App.jsx
@@ -64,8 +64,8 @@ function App() {
         <h2>Lineage growth advantage</h2>
         <p>
           These plots show the estimated growth advantage for given Pango lineages relative to
-          lineage XBB.1.5. This describes how many more secondary infections a variant causes
-          on average relative to lineage XBB.1.5. Vertical bars show the 95% HPD.
+          lineage JN.1. This describes how many more secondary infections a variant causes
+          on average relative to lineage JN.1. Vertical bars show the 95% HPD.
           The "hierarchical" panel shows pooled estimate of growth rates across different locations.
           Results last updated {mlrLineagesData?.modelData?.get('updated') || 'loading'}.
         </p>


### PR DESCRIPTION
Based on @trvrb's notes¹ in today's forecasting meeting:

> Separately, we need to still update the pivot soon as XBB.1.5
> frequencies are becoming quite low in early timesteps. Based on
> previous input, we should just plan to jump directly to JN.1 as baseline.

We don't have an exact matching Nextstrain clade for JN.1 so not updating the pivot for Nextstrain clades in this commit.

¹ https://docs.google.com/document/d/1XFEsF170v-Vof72qZDdjFD3yfT57VbiJBX83h6-becg


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
