### PR TITLE
update-ncov-gisaid-clade-counts: Bump memory

### DIFF
--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -43,7 +43,7 @@ jobs:
       run: |
         nextstrain build \
           --cpus 8 \
-          --memory 16gib \
+          --memory 32gib \
           --env AWS_ACCESS_KEY_ID \
           --env AWS_SECRET_ACCESS_KEY \
           --env SLACK_TOKEN \


### PR DESCRIPTION
Previous triggered run¹ failed with a memory error

```
zstd: error 70 : Write error : cannot write decoded block : Cannot allocate memory
```

¹ https://github.com/nextstrain/forecasts-ncov/actions/runs/8203385071

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Manually triggered run](https://github.com/nextstrain/forecasts-ncov/actions/runs/8208138253)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
