### PR TITLE
Add clade definitions for 24A and 24B

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -93,46 +93,54 @@ mlr_config: "config/mlr-config.yaml"
 # * Lineages which are not a descendant of a clade-defining lineage will be
 #   grouped as 'other'
 clade_definitions:
+  - clade: "24B"
+    display_name: "24B (JN.1.11.1)"
+    defining_lineage: "JN.1.11.1"
+    color: '#DC2F24'
+  - clade: "24A"
+    display_name: "24A (JN.1)"
+    defining_lineage: "JN.1"
+    color: '#E4632E'
   - clade: "23I"
     display_name: "23I (BA.2.86)"
     defining_lineage: "BA.2.86"
-    color: '#DC2F24'
+    color: '#E69136'
   - clade: "23H"
     display_name: "23H (HK.3)"
     defining_lineage: "HK.3"
-    color: '#E56C2F'
+    color: '#D9AD3D'
   - clade: "23G"
     display_name: "23G (XBB.1.5.70)"
     defining_lineage: "XBB.1.5.70"
-    color: '#E39B39'
+    color: '#C1BA47'
   - clade: "23F"
     display_name: "23F (EG.5.1)"
     defining_lineage: "EG.5.1"
-    color: '#CEB541'
+    color: '#A2BE57'
   - clade: "23E"
     display_name: "23E (XBB.2.3)"
     defining_lineage: "XBB.2.3"
-    color: '#ADBD51'
+    color: '#83BA70'
   - clade: "23D"
     display_name: "23D (XBB.1.9)"
     defining_lineage: "XBB.1.9"
-    color: '#88BB6C'
+    color: '#69B091'
   - clade: "23C"
     display_name: "23C (CH.1.1)"
     defining_lineage: "CH.1.1"
-    color: '#69B091'
+    color: '#549DB2'
   - clade: "23B"
     display_name: "23B (XBB.1.16)"
     defining_lineage: "XBB.1.16"
-    color: '#5199B7'
+    color: '#4580CA'
   - clade: "22F"
     display_name: "22F (XBB)"
     defining_lineage: "XBB"
-    color: '#4042C7'
+    color: '#3E58CF'
   - clade: "23A"
     display_name: "23A (XBB.1.5)"
     defining_lineage: "XBB.1.5"
-    color: '#4274CE'
+    color: '#462EB9'
   - clade: "other"
     display_name: "other"
     defining_lineage: False

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -58,14 +58,14 @@ models:
   gisaid:
     nextstrain_clades:
       global:
-        pivot: "23I"
+        pivot: "24A"
     pango_lineages:
       global:
         pivot: "JN.1"
   open:
     nextstrain_clades:
       global:
-        pivot: "23I"
+        pivot: "24A"
     pango_lineages:
       global:
         pivot: "JN.1"

--- a/config/mlr-config.yaml
+++ b/config/mlr-config.yaml
@@ -13,7 +13,7 @@ settings:
 
 model:
   generation_time: 4.8
-  pivot: "23I"
+  pivot: "24A"
   hierarchical: true
 
 inference:

--- a/viz/src/App.jsx
+++ b/viz/src/App.jsx
@@ -41,8 +41,8 @@ function App() {
         <h2>Clade growth advantage</h2>
         <p>
           These plots show the estimated growth advantage for given clades relative to clade
-          23I (lineage BA.2.86). This describes how many more secondary infections a variant causes
-          on average relative to clade 23I. Vertical bars show the 95% HPD. The "hierarchical" panel
+          24A (lineage JN.1). This describes how many more secondary infections a variant causes
+          on average relative to clade 24A. Vertical bars show the 95% HPD. The "hierarchical" panel
           shows pooled estimate of growth rates across different locations.
           Results last updated {mlrCladesData?.modelData?.get('updated') || 'loading'}.
         </p>


### PR DESCRIPTION
## Description of proposed changes

Add new Nextstrain clades 24A and 24B, following up on https://github.com/nextstrain/ncov/pull/1103. 
See commits for details. 


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test run]
  - [x] https://nextstrain.github.io/forecasts-viz/?dataset=https://data.nextstrain.org/files/workflows/forecasts-ncov/trial/add-24A-24B/gisaid/pango_lineages/global/mlr/latest_results.json
  - [x] https://nextstrain.github.io/forecasts-viz/?dataset=https://data.nextstrain.org/files/workflows/forecasts-ncov/trial/add-24A-24B/gisaid/nextstrain_clades/global/mlr/latest_results.json
