### PR TITLE
update-ncov-case-counts: Use GitHub org variable for AWS region

### DIFF
--- a/.github/workflows/update-ncov-case-counts.yaml
+++ b/.github/workflows/update-ncov-case-counts.yaml
@@ -48,7 +48,7 @@ jobs:
 
         ./ingest/vendored/upload-to-s3 global_case_counts.tsv "$S3_DST"/global.tsv.gz $CLOUDFRONT_DOMAIN
       env:
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         TRIAL_NAME: ${{ github.event.inputs.trial_name }}


### PR DESCRIPTION
Organization variable was recently added in https://github.com/nextstrain/zika/pull/54.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] ~Checks pass~ modified workflow isn't part of PR checks
- [ ] Post-merge: Remove `AWS_DEFAULT_REGION` repo secret

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
