### PR TITLE
Reduce clade count threshold

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,7 +20,7 @@ prepare_data:
         location_min_seq_days: 30
         excluded_locations: "defaults/global_excluded_locations.txt"
         prune_seq_days: 12
-        clade_min_seq: 5000
+        clade_min_seq: 2000
         clade_min_seq_days: 150
     pango_lineages:
       global:
@@ -40,7 +40,7 @@ prepare_data:
         location_min_seq_days: 30
         excluded_locations: "defaults/global_excluded_locations.txt"
         prune_seq_days: 12
-        clade_min_seq: 5000
+        clade_min_seq: 2000
         clade_min_seq_days: 150
     pango_lineages:
       global:


### PR DESCRIPTION
This reduces the threshold for a clade to be included (and not wrapped into "other") from 5000 total sequences to 2000 total sequences. This causes clade 24B to be broken out in the current data.

![clades-threshold](https://github.com/nextstrain/forecasts-ncov/assets/1176109/34f45dbb-4142-4a08-8426-6d2f237606d9)

There may be other changes to thresholds to pull in more geography, but I think this is a nice simple change to keep up with decreased sequencing volume.