### PR TITLE
Reduce location count thresholds

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,7 +16,7 @@ prepare_data:
     nextstrain_clades:
       global:
         included_days: 150
-        location_min_seq: 100
+        location_min_seq: 50
         location_min_seq_days: 30
         excluded_locations: "defaults/global_excluded_locations.txt"
         prune_seq_days: 12
@@ -25,7 +25,7 @@ prepare_data:
     pango_lineages:
       global:
         included_days: 150
-        location_min_seq: 300
+        location_min_seq: 150
         location_min_seq_days: 30
         excluded_locations: "defaults/global_excluded_locations.txt"
         prune_seq_days: 12
@@ -36,7 +36,7 @@ prepare_data:
     nextstrain_clades:
       global:
         included_days: 150
-        location_min_seq: 100
+        location_min_seq: 50
         location_min_seq_days: 30
         excluded_locations: "defaults/global_excluded_locations.txt"
         prune_seq_days: 12
@@ -45,7 +45,7 @@ prepare_data:
     pango_lineages:
       global:
         included_days: 150
-        location_min_seq: 300
+        location_min_seq: 150
         location_min_seq_days: 30
         excluded_locations: "defaults/global_excluded_locations.txt"
         prune_seq_days: 12

--- a/viz/src/App.jsx
+++ b/viz/src/App.jsx
@@ -31,7 +31,7 @@ function App() {
         <p>
           Each line represents the estimated frequency of a particular clade through time.
           Equivalent Pango lineage is given in parenthesis, eg clade 23A (lineage XBB.1.5). Only
-          locations with more than 100 sequences from samples collected in the previous 150 days are
+          locations with more than 50 sequences from samples collected in the previous 30 days are
           included. Results last updated {mlrCladesData?.modelData?.get('updated') || 'loading'}.
         </p>
         <div id="cladeFrequenciesPanel" class="panelDisplay"> {/* surrounding div(s) used for static-images.js script */}
@@ -54,7 +54,7 @@ function App() {
         <p>
           Each line represents the estimated frequency of a particular Pango lineage through time.
           Lineages with fewer than 350 observations are collapsed into parental lineage. Only
-          locations with more than 300 sequences from samples collected in the previous 150 days are
+          locations with more than 150 sequences from samples collected in the previous 30 days are
           included. Results last updated {mlrLineagesData?.modelData?.get('updated') || 'loading'}.
         </p>
         <div id="lineageFrequenciesPanel" class="panelDisplay">


### PR DESCRIPTION
This PR drops location count threshold (ie the number of sequences collected in the past 30 days) from 100 to 50 for clade-level analysis and from 300 to 150 for lineage-level analysis.

With current data this goes from 8 locations included for clades to 11 locations included.

With current data this goes from 5 locations included for lineages to 7 locations included.

To support these thresholds, I looked at location count for different countries analyzed in [bedford.io/papers/abousamra-ncov-forecasting-fit/](https://bedford.io/papers/abousamra-ncov-forecasting-fit/) to get specific count thresholds. We see:
- Trinidad and Tobago with 2.3k sequences collected in 2022 and a median 30-day sequence count of 43 with a mean absolute forecasting error of 12%
- Vietnam with 6k sequences collected in 2022 and a median 30-day sequence count of 30 with a mean absolute forecasting error of 11%
- South Africa with 16k sequences collected in 2022 and a median 30-day sequence count of 170 with a mean absolute forecasting error of 7%

I believe this suggests that a threshold of 50 sequences in previous 30 days should be roughly consistent with a ~10% forecasting error. This seems like an okay threshold for public display.

It's less certain what count threshold to use for lineages where we have significantly larger number of labels than we do for clades. Keeping a 3x ratio here for now.

![recent-sequences-Trinidad and Tobago](https://github.com/nextstrain/forecasts-ncov/assets/1176109/8db8d7a8-b873-438d-a5d8-d9450ba2f861)

![recent-sequences-Vietnam](https://github.com/nextstrain/forecasts-ncov/assets/1176109/013a5183-d01c-4fb5-9760-c57a88faa080)

![recent-sequences-South Africa](https://github.com/nextstrain/forecasts-ncov/assets/1176109/e8329986-7403-4312-9675-d586ee978bd7)


