### PR TITLE
Update clade definitions

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -96,51 +96,15 @@ clade_definitions:
   - clade: "24C"
     display_name: "24C (KP.3)"
     defining_lineage: "KP.3"
-    color: '#DC2F24'
+    color: '#CBB742'
   - clade: "24B"
     display_name: "24B (JN.1.11.1)"
     defining_lineage: "JN.1.11.1"
-    color: '#E4632E'
+    color: '#7EB876'
   - clade: "24A"
     display_name: "24A (JN.1)"
     defining_lineage: "JN.1"
-    color: '#E69136'
-  - clade: "23I"
-    display_name: "23I (BA.2.86)"
-    defining_lineage: "BA.2.86"
-    color: '#D9AD3D'
-  - clade: "23H"
-    display_name: "23H (HK.3)"
-    defining_lineage: "HK.3"
-    color: '#C1BA47'
-  - clade: "23G"
-    display_name: "23G (XBB.1.5.70)"
-    defining_lineage: "XBB.1.5.70"
-    color: '#A2BE57'
-  - clade: "23F"
-    display_name: "23F (EG.5.1)"
-    defining_lineage: "EG.5.1"
-    color: '#83BA70'
-  - clade: "23E"
-    display_name: "23E (XBB.2.3)"
-    defining_lineage: "XBB.2.3"
-    color: '#69B091'
-  - clade: "23D"
-    display_name: "23D (XBB.1.9)"
-    defining_lineage: "XBB.1.9"
-    color: '#549DB2'
-  - clade: "23C"
-    display_name: "23C (CH.1.1)"
-    defining_lineage: "CH.1.1"
-    color: '#4580CA'
-  - clade: "23B"
-    display_name: "23B (XBB.1.16)"
-    defining_lineage: "XBB.1.16"
-    color: '#3E58CF'
-  - clade: "22F"
-    display_name: "22F (XBB)"
-    defining_lineage: "XBB"
-    color: '#462EB9'
+    color: '#4988C5'
   - clade: "other"
     display_name: "other"
     defining_lineage: False


### PR DESCRIPTION
Previous clades including 23B, 23C, ..., 23I are all now extinct or rare enough that extant examples are getting lumped into the "other" bin. With the current clade definitions these extinct clades are taking up all the color bandwidth and the three relevant clades of 24A, 24B and 24C are all similar shades of red.

This commit removes extinct clades and updates colors for surviving clades.

### Clade frequencies on `main`

<img width="1199" alt="Screenshot 2024-09-11 at 12 59 33 PM" src="https://github.com/user-attachments/assets/7e16e207-b4f0-48ed-bd9c-4eaa3205073f">

### Clade frequencies with PR

<img width="1050" alt="ncov_forecasts_clades_2024_09_09" src="https://github.com/user-attachments/assets/c4fc30ed-4c2a-40a6-83ff-db65a6bf0304">

### Lineage growth advantages on `main`

<img width="1199" alt="Screenshot 2024-09-11 at 1 01 01 PM" src="https://github.com/user-attachments/assets/2c04d841-d090-4fbe-aec9-f964ba4768f2">


### Lineage growth advantages with PR

<img width="1002" alt="Screenshot 2024-09-11 at 1 01 55 PM" src="https://github.com/user-attachments/assets/034a86d8-5313-4f09-a109-bfa0c9a1d671">

@joverlee521 or @jameshadfield, could you take a quick look at this?

