### PR TITLE
dev: Stop using Mambaforge in CI; the Miniforge3 installer is now equivalent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: "3.9"
-        miniforge-variant: Mambaforge
+        miniforge-version: latest
         channels: conda-forge,bioconda
 
     - name: Install Cram


### PR DESCRIPTION
CI runs will start failing due to Mambaforge brownouts ahead of its removal in January 2025; it was deprecated in late July 2024.¹

¹ <https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
