### PR TITLE
run-models.yaml: Pin docker-base image

### DIFF
--- a/.github/workflows/run-models.yaml
+++ b/.github/workflows/run-models.yaml
@@ -60,7 +60,7 @@ jobs:
           --aws-batch \
           --detach \
           --no-download \
-          --image nextstrain/base \
+          --image nextstrain/base:build-20241120T183024Z \
           --cpus 8 \
           --memory 16GiB \
           --env AWS_DEFAULT_REGION \


### PR DESCRIPTION
## Description of proposed changes

Pinning the docker-base image used for model workflows as a temporary workaround for https://github.com/nextstrain/forecasts-ncov/issues/113

This can be unpinned once the fix in evofr is merged and released.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test run](https://github.com/nextstrain/forecasts-ncov/actions/runs/12205611558)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
