### PR TITLE
Revert "run-models.yaml: Pin docker-base image"

### DIFF
--- a/.github/workflows/run-models.yaml
+++ b/.github/workflows/run-models.yaml
@@ -60,7 +60,7 @@ jobs:
           --aws-batch \
           --detach \
           --no-download \
-          --image nextstrain/base:build-20241120T183024Z \
+          --image nextstrain/base \
           --cpus 8 \
           --memory 16GiB \
           --env AWS_DEFAULT_REGION \


### PR DESCRIPTION
This reverts commit 83dee5e090a9775c8c336e86d6cb4cb95b4e9325.

The upstream issue in evofr has been fixed and released in v0.1.26. and has been included in the latest nextstrain/base image.

## Related issue(s)

Related to https://github.com/nextstrain/forecasts-ncov/issues/113

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [x] [trial model run](https://github.com/nextstrain/forecasts-ncov/actions/runs/12382691572)
<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
