### PR TITLE
gisaid-clade-counts: Temporarily skip `trigger_model_runs` job

### DIFF
--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -56,7 +56,9 @@ jobs:
 
   trigger_model_runs:
     needs: [gisaid_clade_counts]
-    if: ${{ !github.event.inputs.trial_name }}
+    # Temporarily disable the run-models workflow due to
+    # <https://github.com/nextstrain/forecasts-ncov/issues/117>
+    if: false
     runs-on: ubuntu-latest
     steps:
       - run: gh workflow run run-models.yaml --repo nextstrain/forecasts-ncov -f data_provenance=gisaid


### PR DESCRIPTION
Temporarily skip the `trigger_model_runs` job since we do not have enough sequence data to run the models

<https://github.com/nextstrain/forecasts-ncov/issues/117>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial run](https://github.com/nextstrain/forecasts-ncov/actions/runs/12753690639)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
