### PR TITLE
open-clade-counts: Skip `trigger_model_runs` job

### DIFF
--- a/.github/workflows/update-ncov-open-clade-counts.yaml
+++ b/.github/workflows/update-ncov-open-clade-counts.yaml
@@ -57,7 +57,9 @@ jobs:
 
   trigger_model_runs:
     needs: [open_clade_counts]
-    if: ${{ !github.event.inputs.trial_name }}
+    # Disable the run-model workflow due to low sequence counts
+    # <https://github.com/nextstrain/forecasts-ncov/issues/119>
+    if: false
     runs-on: ubuntu-latest
     steps:
       - run: gh workflow run run-models.yaml --repo nextstrain/forecasts-ncov -f data_provenance=open


### PR DESCRIPTION
## Description of proposed changes
Skip the `trigger_model_runs` job due to low sequence counts. This only disables the automated model runs, we can still manually trigger the run-models workflow for open/GenBank data. We can revisit whether to restart it when we do a review of sequence count cutoffs.

## Related issue(s)

Prompted by https://github.com/nextstrain/forecasts-ncov/issues/119

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
