### PR TITLE
Include a location x variant count threshold for inclusion of GA

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -55,20 +55,20 @@ models:
     nextstrain_clades:
       global:
         pivot: "24F"
-        location_ga_inclusion_threshold: 100
+        location_ga_inclusion_threshold: 25
     pango_lineages:
       global:
         pivot: "XEC"
-        location_ga_inclusion_threshold: 100
+        location_ga_inclusion_threshold: 25
   open:
     nextstrain_clades:
       global:
         pivot: "24F"
-        location_ga_inclusion_threshold: 100
+        location_ga_inclusion_threshold: 25
     pango_lineages:
       global:
         pivot: "XEC"
-        location_ga_inclusion_threshold: 100
+        location_ga_inclusion_threshold: 25
 
 # Model configs
 mlr_config: "config/mlr-config.yaml"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -55,16 +55,20 @@ models:
     nextstrain_clades:
       global:
         pivot: "24F"
+        location_ga_inclusion_threshold: 100
     pango_lineages:
       global:
         pivot: "XEC"
+        location_ga_inclusion_threshold: 100
   open:
     nextstrain_clades:
       global:
         pivot: "24F"
+        location_ga_inclusion_threshold: 100
     pango_lineages:
       global:
         pivot: "XEC"
+        location_ga_inclusion_threshold: 100
 
 # Model configs
 mlr_config: "config/mlr-config.yaml"

--- a/scripts/run-mlr-model.py
+++ b/scripts/run-mlr-model.py
@@ -389,15 +389,14 @@ def export_results(multi_posterior, ps, path, data_name, hier, pivot, ga_inclusi
 
     ef.save_json(results, path=f"{path}/{data_name}_results.json")
 
-def positive_int(value):
+def nonnegative_int(value):
     """
     Custom argparse type function to verify only
     positive integers are provided as arguments
     """
     int_value = int(value)
     if int_value <= 0:
-        print(f"ERROR: {int_value} is not a positive integer.", file=sys.stderr)
-        sys.exit(1)
+        raise argparse.ArgumentTypeError(f"{int_value} is not a positive integer.")
     return int_value
 
 if __name__ == "__main__":
@@ -431,9 +430,10 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--location-ga-inclusion-threshold", type=positive_int, default=0,
+        "--location-ga-inclusion-threshold", type=nonnegative_int, default=0,
         help="Mininum number of sequences that need to be observed for a specific "
-        + "location x variant combination."
+        + "location x variant combination. Default is 0, ie including all combinations "
+        + "even if there isn't data for a particular combination."
     )
 
     args = parser.parse_args()
@@ -447,8 +447,7 @@ if __name__ == "__main__":
     print("Data loaded successfully")
 
     # Calculate variant x location sequence counts
-    seq_data = pd.read_csv(args.seq_path, sep="\t")
-    variant_location_counts = seq_data.groupby(["location", "variant"])["sequences"].sum().to_dict()
+    variant_location_counts = raw_seq.groupby(["location", "variant"])["sequences"].sum().to_dict()
     print("variant_location_counts:", variant_location_counts)
 
     override_hier = None

--- a/viz/src/App.jsx
+++ b/viz/src/App.jsx
@@ -33,10 +33,9 @@ function App() {
       <div id="mainPanelsContainer">
         <h2>Clade frequencies over time</h2>
         <p>
-          Each line represents the estimated frequency of a particular clade through time.
-          Equivalent Pango lineage is given in parenthesis, eg clade 23A (lineage XBB.1.5). Only
-          locations with more than 1000 sequences from samples collected in the previous 150 days are
-          included. Results last updated {mlrCladesData?.modelData?.get('updated') || 'loading'}.
+          Each line represents the estimated frequency of a particular clade through time. Equivalent Pango lineage is given
+          in parenthesis, eg clade 23A (lineage XBB.1.5). Only locations with more than 1000 sequences from samples collected
+          in the previous 150 days are included. Results last updated {mlrCladesData?.modelData?.get('updated') || 'loading'}.
         </p>
         <div id="cladeFrequenciesPanel" class="panelDisplay"> {/* surrounding div(s) used for static-images.js script */}
           <PanelDisplay data={mlrCladesData} locations={cladesLocationsFiltered} params={{preset: "frequency"}}/>
@@ -44,11 +43,11 @@ function App() {
 
         <h2>Clade growth advantage</h2>
         <p>
-          These plots show the estimated growth advantage for given clades relative to
-          clade {mlrCladesPivot}. This describes how many more secondary infections a variant causes
-          on average relative to clade {mlrCladesPivot}. Vertical bars show the 95% HPD. The "hierarchical" panel
-          shows pooled estimate of growth rates across different locations.
-          Results last updated {mlrCladesData?.modelData?.get('updated') || 'loading'}.
+          These plots show the estimated growth advantage for given clades relative to clade {mlrCladesPivot}. This
+          describes how many more secondary infections a variant causes on average relative to clade {mlrCladesPivot}.
+          Vertical bars show the 95% HPD. The "hierarchical" panel shows pooled estimate of growth rates across different
+          locations. Not all clades circulate in all locations and only estimates for clades with at least 25 observations
+          in a location are shown. Results last updated {mlrCladesData?.modelData?.get('updated') || 'loading'}.
         </p>
         <div id="cladeGrowthAdvantagePanel" class="panelDisplay">
           <PanelDisplay data={mlrCladesData} params={{preset: "growthAdvantage"}}/>
@@ -56,10 +55,10 @@ function App() {
 
         <h2>Lineage frequencies over time</h2>
         <p>
-          Each line represents the estimated frequency of a particular Pango lineage through time.
-          Lineages with fewer than 350 observations are collapsed into parental lineage. Only
-          locations with more than 1000 sequences from samples collected in the previous 150 days are
-          included. Results last updated {mlrLineagesData?.modelData?.get('updated') || 'loading'}.
+          Each line represents the estimated frequency of a particular Pango lineage through time. Lineages with fewer
+          than 350 observations are collapsed into parental lineage. Only locations with more than 1000 sequences from
+          samples collected in the previous 150 days are included. Results last updated
+          {mlrLineagesData?.modelData?.get('updated') || 'loading'}.
         </p>
         <div id="lineageFrequenciesPanel" class="panelDisplay">
           <PanelDisplay data={mlrLineagesData} locations={lineagesLocationsFiltered} params={{preset: "frequency"}}/>
@@ -67,11 +66,12 @@ function App() {
 
         <h2>Lineage growth advantage</h2>
         <p>
-          These plots show the estimated growth advantage for given Pango lineages relative to
-          lineage {mlrLineagesPivot}. This describes how many more secondary infections a variant causes
-          on average relative to lineage {mlrLineagesPivot}. Vertical bars show the 95% HPD.
-          The "hierarchical" panel shows pooled estimate of growth rates across different locations.
-          Results last updated {mlrLineagesData?.modelData?.get('updated') || 'loading'}.
+          These plots show the estimated growth advantage for given Pango lineages relative to lineage {mlrLineagesPivot}.
+          This describes how many more secondary infections a variant causes on average relative to lineage
+          {mlrLineagesPivot}. Vertical bars show the 95% HPD. The "hierarchical" panel shows pooled estimate of growth
+          rates across different locations. Not all lineages circulate in all locations and only estimates for lineages with
+          at least 25 observations in a location are shown. Results last updated
+          {mlrLineagesData?.modelData?.get('updated') || 'loading'}.
         </p>
         <div id="lineageGrowthAdvantagePanel" class="panelDisplay">
           <PanelDisplay data={mlrLineagesData} params={{preset: "growthAdvantage"}}/>

--- a/workflow/snakemake_rules/models.smk
+++ b/workflow/snakemake_rules/models.smk
@@ -77,7 +77,8 @@ rule mlr_model:
     params:
         renewal_config = config.get("mlr_config"),
         export_path = lambda w: f"results/{w.data_provenance}/{w.variant_classification}/{w.geo_resolution}/mlr/model-outputs",
-        pivot = lambda wildcards: _get_models_option(wildcards, 'pivot')
+        pivot = lambda wildcards: _get_models_option(wildcards, 'pivot'),
+        location_ga_inclusion_threshold = lambda wildcards: _get_models_option(wildcards, 'location_ga_inclusion_threshold')
     resources:
         mem_mb=4000
     shell:
@@ -87,6 +88,7 @@ rule mlr_model:
             --seq-path {input.sequence_counts} \
             --export-path {params.export_path} \
             {params.pivot} \
+            {params.location_ga_inclusion_threshold} \
             --data-name {wildcards.date} 2>&1 | tee {log}
         """
 


### PR DESCRIPTION
Previously, the growth advantage was included for each location and each variant regardless of the amount of data available for this particular location x variant combination. There would be situations where there is 0 sequences for a particular variant in a particular location and we'd still display the growth advantage (which was just the hierarchical prior).

This PR adds an option of `--location-ga-inclusion-threshold` to `run-mlr-model.py`. I've initially set this to 100, which seemed to work well at least heuristically.

<img width="1233" alt="Screenshot 2025-02-26 at 2 45 18 PM" src="https://github.com/user-attachments/assets/9330b886-4218-44a8-ba14-2c6c1f4121ba" />

