### PR TITLE
Add USA-specific model

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,10 @@ prepare_data:
         excluded_locations: "defaults/global_excluded_locations.txt"
         clade_min_seq: 500
         clade_min_seq_days: 150
+      usa:
+        included_days: 150
+        location_min_seq: 100
+        location_min_seq_days: 100
     pango_lineages:
       global:
         included_days: 150
@@ -54,6 +58,9 @@ models:
   gisaid:
     nextstrain_clades:
       global:
+        pivot: "24F"
+        location_ga_inclusion_threshold: 25
+      usa:
         pivot: "24F"
         location_ga_inclusion_threshold: 25
     pango_lineages:


### PR DESCRIPTION
## Description of proposed changes

This PR adds a USA-specific frequency estimates for states and territories by implementing the following steps:

 - [ ] Download tasks.json [from the GitHub repo](https://github.com/reichlab/variant-nowcast-hub/blob/main/hub-config/tasks.json) to get the most recent nowcast round date and list of clades to model.
 - [x] Run the MLR model for USA with GISAID data and Nextstrain clades. Adds minimal configuration parameters to support a GISAID-based, USA-specific model of Nextstrain clade frequencies per state. I copied the number of included days for the model fit from the other models and set the 100 minimum sequences per location in the last 100 days after inspecting model estimates at different thresholds. These settings effectively filter out states with no recent sequences (Alabama, Alaska, and Arkansas) or states with a few large sets of older sequences (North Carolina and Tennessee).
 - [ ] Prepare a hub submission for the MLR model
 - [ ] Submit parquet to GitHub repository

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Closes #132 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
