### PR TITLE
Finish GitHub Action to upload model results

### DIFF
--- a/.github/workflows/run-usa-models.yaml
+++ b/.github/workflows/run-usa-models.yaml
@@ -9,29 +9,49 @@ jobs:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
     secrets: inherit
     with:
-      runtime: aws-batch
+      runtime: docker
       run: |
         nextstrain build \
-          --aws-batch \
-          --detach \
-          --no-download \
           --image nextstrain/base \
-          --cpus 8 \
-          --memory 16GiB \
           --env AWS_DEFAULT_REGION \
           --env GITHUB_RUN_ID \
-          --env GIT_AUTHOR_EMAIL \
-          --env GIT_AUTHOR_NAME \
-          --env GIT_COMMITTER_EMAIL \
-          --env GIT_COMMITTER_NAME \
-          --env GITHUB_TOKEN \
           . \
-            push_all_hub_submissions \
+            prepare_all_hub_submissions \
             --configfile config/config.yaml config/variant_hub.yaml
       env: |
         GITHUB_RUN_ID: ${{ github.run_id }}
-        GIT_AUTHOR_EMAIL: ${{ vars.GIT_USER_EMAIL_NEXTSTRAIN_BOT }}
-        GIT_AUTHOR_NAME: ${{ vars.GIT_USER_NAME_NEXTSTRAIN_BOT }}
-        GIT_COMMITTER_EMAIL: ${{ vars.GIT_USER_EMAIL_NEXTSTRAIN_BOT }}
-        GIT_COMMITTER_NAME: ${{ vars.GIT_USER_NAME_NEXTSTRAIN_BOT }}
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}
+      artifact-name: model-outputs
+      artifact-paths: |
+        hub/submissions.txt
+        hub/model-output/
+        !results/
+  upload_models:
+    needs: [run_models]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract model outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: model-outputs
+      - name: Clone fork of variant nowcast hub
+        uses: actions/checkout@v4
+        with:
+          repository: nextstrain/variant-nowcast-hub
+          path: variant-nowcast-hub
+          token: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}
+      - name: Upload model outputs to hub fork
+        run: |
+          rsync -arvz --files-from=hub/submissions.txt hub/ variant-nowcast-hub/
+
+          cd variant-nowcast-hub
+          export DATE="$(date "+%Y-%m-%d")"
+          git switch -c blab-${DATE}
+          git add --pathspec-from-file=../hub/submissions.txt
+          git commit -m "Add blab models for ${DATE}"
+          git push origin blab-${DATE}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}
+          GIT_AUTHOR_EMAIL: ${{ vars.GIT_USER_EMAIL_NEXTSTRAIN_BOT }}
+          GIT_AUTHOR_NAME: ${{ vars.GIT_USER_NAME_NEXTSTRAIN_BOT }}
+          GIT_COMMITTER_EMAIL: ${{ vars.GIT_USER_EMAIL_NEXTSTRAIN_BOT }}
+          GIT_COMMITTER_NAME: ${{ vars.GIT_USER_NAME_NEXTSTRAIN_BOT }}

--- a/config/variant_hub.yaml
+++ b/config/variant_hub.yaml
@@ -12,7 +12,3 @@ hub_models:
     data_provenance: gisaid
     variant_classification: nextstrain_clades
     geo_resolution: usa
-
-# Submit model results to the hub through a fork of the official GitHub
-# repository.
-hub_github_fork_url: https://github.com/nextstrain/variant-nowcast-hub


### PR DESCRIPTION
## Description of proposed changes

Updates the original stubbed GitHub Action workflow to actually run the USA-specific models and upload the resulting files to a fork of the variant hub repository. To get this working properly without exposing GitHub tokens through shell commands, I ended up moving the git logic out of the Snakemake workflow and into GitHub Actions. This approach allowed me to use GHA's automatic permissions management (e.g., passing tokens from secrets for cloning and pushing repos) to safely enable writing to a different repository.

For this approach to work, I needed to run the models in one job with the Docker Nextstrain runtime instead of the AWS Batch runtime, so I could save the parquet file outputs as artifacts for the second job. The first job creates a list of model files to be uploaded and the second job uses that list to add those files into the forked repo.

## Related issue(s)

Continues work from #133 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [GHA uploads model files to dated branch](https://github.com/nextstrain/forecasts-ncov/actions/runs/15448730467/job/43485486681#step:4:34)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
