### PR TITLE
Add clade 25C to clade definitions

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -101,6 +101,10 @@ mlr_config: "config/mlr-config.yaml"
 # * Lineages which are not a descendant of a clade-defining lineage will be
 #   grouped as 'other'
 clade_definitions:
+  - clade: "25C"
+    display_name: "25C (XFG)"
+    defining_lineage: "XFG"
+    color: '#DC2F24'
   - clade: "25B"
     display_name: "25B (NB.1.8.1)"
     defining_lineage: "NB.1.8.1"


### PR DESCRIPTION
## Description of proposed changes

Clade 25C was added in <https://github.com/nextstrain/ncov/pull/1177>.
Released in the Nextclade SARS-CoV-2 dataset in [2025-06-09--15-42-38Z](https://github.com/nextstrain/nextclade_data/releases/tag/2025-06-09--15-42-38Z).

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
