### PR TITLE
Cast dates in hub submissions to parquet date type

### DIFF
--- a/scripts/prepare_hub_submission.py
+++ b/scripts/prepare_hub_submission.py
@@ -166,5 +166,10 @@ if __name__ == '__main__':
     all_frequencies = records.groupby(["output_type_id", "target_date"])["value"].sum().values
     assert np.allclose(all_frequencies, np.ones(all_frequencies.shape))
 
+    # Convert date columns to pandas date type and then to the parquet date type
+    # required for our hub submissions.
+    for date_column in ("nowcast_date", "target_date"):
+        records[date_column] = pd.to_datetime(records[date_column], utc=True).astype("date32[pyarrow]")
+
     # Save estimates to a parquet file.
     records.to_parquet(args.output)


### PR DESCRIPTION
## Description of proposed changes

Fixes a validation error with our parquet file submissions to the variant nowcast hub by explicitly casting date columns to the 32-bit parquet date type. This casting relies on pyarrow's support for these parquet types that do not exist in fastparquet.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Depends on https://github.com/nextstrain/docker-base/pull/252
Fixes validation errors in https://github.com/reichlab/variant-nowcast-hub/pull/582

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
