### PR TITLE
ingest/fetch-ncov-global-case-counts: Use new endpoint

### DIFF
--- a/.github/workflows/update-ncov-case-counts.yaml
+++ b/.github/workflows/update-ncov-case-counts.yaml
@@ -40,6 +40,8 @@ jobs:
       runtime: docker
       run: |
         nextstrain build \
+          --env SLACK_TOKEN \
+          --env SLACK_CHANNELS \
           ingest \
           upload_all_case_counts \
           --config s3_dst="$S3_DST"

--- a/ingest/bin/fetch-ncov-global-case-counts
+++ b/ingest/bin/fetch-ncov-global-case-counts
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 # Fetch CSV from Our World in Data
-curl https://covid.ourworldindata.org/data/owid-covid-data.csv \
+curl https://catalog.ourworldindata.org/garden/covid/latest/compact/compact.csv \
     --fail --silent --show-error --location \
     --header 'User-Agent: https://github.com/nextstrain/counts (hello@nextstrain.org)' |
-    # Only keep the date, location, and new_cases columns
-    csvtk cut -f location,date,new_cases |
-    # Rename new_cases to cases
-    csvtk rename -f new_cases -n cases |
+    # Only keep the date, country, and new_cases columns
+    csvtk cut -f country,date,new_cases |
+    # Rename new_cases to cases and country to location
+    csvtk rename -f new_cases,country -n cases,location |
     # Only keep rows that have more than 0 cases
     csvtk filter -f "cases>0" |
     # Remove decimals from case counts


### PR DESCRIPTION
## Description of proposed changes

The case counts GH Action workflow failed this morning¹ which reminded me  of https://github.com/nextstrain/forecasts-ncov/issues/131.

I'm opting to just update the case counts script to use the new endpoint and  we can discuss separately whether case counts are still needed. 

¹ <https://github.com/nextstrain/forecasts-ncov/actions/runs/16449666904>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial run](https://github.com/nextstrain/forecasts-ncov/actions/runs/16452311328)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
