### PR TITLE
Add wildcard constraints to fix PeriodicWildcardError

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -25,6 +25,11 @@ if config.get("send_slack_notifications"):
         sys.exit(1)
 
 wildcard_constraints:
+    # These constraints are to prevent '"PeriodicWildcardError in rule post_process'
+    model="[^/]+",
+    variant_classification="[^/]+",
+    geo_resolution="[^/]+",
+    data_provenance="gisaid|open",
     date = r"\d{4}-\d{2}-\d{2}"
 
 def get_todays_date():

--- a/workflow/snakemake_rules/models.smk
+++ b/workflow/snakemake_rules/models.smk
@@ -4,13 +4,6 @@ This part of the workflow runs the model scripts.
 
 import json
 
-# These constraints are to prevent '"PeriodicWildcardError in rule post_process'
-wildcard_constraints:
-    model="[^/]+",
-    variant_classification="[^/]+",
-    geo_resolution="[^/]+",
-    data_provenance="gisaid|open",
-
 def _get_sequence_counts_input(wildcards):
     if wildcards.variant_classification == 'pango_lineages':
         return "data/{data_provenance}/{variant_classification}/{geo_resolution}/collapsed_seq_counts.tsv"

--- a/workflow/snakemake_rules/models.smk
+++ b/workflow/snakemake_rules/models.smk
@@ -4,6 +4,13 @@ This part of the workflow runs the model scripts.
 
 import json
 
+# These constraints are to prevent '"PeriodicWildcardError in rule post_process'
+wildcard_constraints:
+    model="[^/]+",
+    variant_classification="[^/]+",
+    geo_resolution="[^/]+",
+    data_provenance="gisaid|open",
+
 def _get_sequence_counts_input(wildcards):
     if wildcards.variant_classification == 'pango_lineages':
         return "data/{data_provenance}/{variant_classification}/{geo_resolution}/collapsed_seq_counts.tsv"


### PR DESCRIPTION
Without the constraints I get the following warnings on snakemake 9.8.1:

```
PeriodicWildcardError in rule post_process in file "/Users/cr/code/forecasts-ncov/workflow/snakemake_rules/models.smk", line 115:
The value /model-outputs in wildcard geo_resolution is periodically repeated (global/mlr/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs/model-outputs). This would lead to an infinite recursion. To avoid this, e.g. restrict the wildcards in this rule to certain values.
```
